### PR TITLE
Update bootenvs to reference bootenvs correctly.

### DIFF
--- a/embedded/assets/bootenvs/centos-6.6.json
+++ b/embedded/assets/bootenvs/centos-6.6.json
@@ -24,27 +24,27 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "centos-6.ks.tmpl"
+            "ID": "centos-6.ks.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/centos-6.8.json
+++ b/embedded/assets/bootenvs/centos-6.8.json
@@ -24,27 +24,27 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "centos-6.ks.tmpl"
+            "ID": "centos-6.ks.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/centos-7.1.1503.json
+++ b/embedded/assets/bootenvs/centos-7.1.1503.json
@@ -24,27 +24,27 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "centos-7.ks.tmpl"
+            "ID": "centos-7.ks.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/centos-7.2.1511.json
+++ b/embedded/assets/bootenvs/centos-7.2.1511.json
@@ -24,27 +24,27 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "centos-7.ks.tmpl"
+            "ID": "centos-7.ks.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/centos-7.3.1611.json
+++ b/embedded/assets/bootenvs/centos-7.3.1611.json
@@ -24,27 +24,27 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "centos-7.ks.tmpl"
+            "ID": "centos-7.ks.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/debian-7.json
+++ b/embedded/assets/bootenvs/debian-7.json
@@ -29,32 +29,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "seed",
             "Path": "{{.Machine.Path}}/seed",
-            "UUID": "net_seed.tmpl"
+            "ID": "net_seed.tmpl"
         },
         {
             "Name": "net-post-install.sh",
             "Path": "{{.Machine.Path}}/post-install.sh",
-            "UUID": "net-post-install.sh.tmpl"
+            "ID": "net-post-install.sh.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/debian-8.json
+++ b/embedded/assets/bootenvs/debian-8.json
@@ -29,32 +29,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "seed",
             "Path": "{{.Machine.Path}}/seed",
-            "UUID": "net_seed.tmpl"
+            "ID": "net_seed.tmpl"
         },
         {
             "Name": "net-post-install.sh",
             "Path": "{{.Machine.Path}}/post-install.sh",
-            "UUID": "net-post-install.sh.tmpl"
+            "ID": "net-post-install.sh.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/esxi-6u2.json
+++ b/embedded/assets/bootenvs/esxi-6u2.json
@@ -16,32 +16,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "esxi-chain-pxelinux.tmpl"
+            "ID": "esxi-chain-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "esxi-6u2.ipxe.cfg.tmpl"
+            "ID": "esxi-6u2.ipxe.cfg.tmpl"
         },
         {
             "Name": "pxelinux-chain",
             "Path": "{{.Env.PathFor \"tftp\" \"\"}}/pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "esxi-pxelinux.tmpl"
+            "ID": "esxi-pxelinux.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "esxi-install.ks.tmpl"
+            "ID": "esxi-install.ks.tmpl"
         },
         {
             "Name": "boot.cfg",
             "Path": "{{.Env.PathFor \"tftp\" \"\"}}/{{.Machine.Path}}/boot.cfg",
-            "UUID": "esxi-6u2.boot.cfg.tmpl"
+            "ID": "esxi-6u2.boot.cfg.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/local.json
+++ b/embedded/assets/bootenvs/local.json
@@ -8,17 +8,17 @@
         {
             "Name": "pxelinux",
             "Path": "discovery/pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "local-pxelinux.tmpl"
+            "ID": "local-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "discovery/{{.Machine.HexAddress}}.conf",
-            "UUID": "local-elilo.tmpl"
+            "ID": "local-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "discovery/{{.Machine.Address}}.ipxe",
-            "UUID": "local-ipxe.tmpl"
+            "ID": "local-ipxe.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/redhat-6.5.json
+++ b/embedded/assets/bootenvs/redhat-6.5.json
@@ -23,27 +23,27 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "centos-6.ks.tmpl"
+            "ID": "centos-6.ks.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/redhat-7.0.json
+++ b/embedded/assets/bootenvs/redhat-7.0.json
@@ -21,27 +21,27 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "centos-7.ks.tmpl"
+            "ID": "centos-7.ks.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/scientificlinux-6.8.json
+++ b/embedded/assets/bootenvs/scientificlinux-6.8.json
@@ -24,27 +24,27 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "compute.ks",
             "Path": "{{.Machine.Path}}/compute.ks",
-            "UUID": "centos-6.ks.tmpl"
+            "ID": "centos-6.ks.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/sledgehammer.json
+++ b/embedded/assets/bootenvs/sledgehammer.json
@@ -12,22 +12,22 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "control.sh",
             "Path": "{{.Machine.Path}}/control.sh",
-            "UUID": "sledgehammer-control.sh.tmpl"
+            "ID": "sledgehammer-control.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/ubuntu-12.04.json
+++ b/embedded/assets/bootenvs/ubuntu-12.04.json
@@ -29,32 +29,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "seed",
             "Path": "{{.Machine.Path}}/seed",
-            "UUID": "net_seed.tmpl"
+            "ID": "net_seed.tmpl"
         },
         {
             "Name": "net-post-install.sh",
             "Path": "{{.Machine.Path}}/post-install.sh",
-            "UUID": "net-post-install.sh.tmpl"
+            "ID": "net-post-install.sh.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/ubuntu-14.04.3.json
+++ b/embedded/assets/bootenvs/ubuntu-14.04.3.json
@@ -29,32 +29,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "seed",
             "Path": "{{.Machine.Path}}/seed",
-            "UUID": "net_seed.tmpl"
+            "ID": "net_seed.tmpl"
         },
         {
             "Name": "net-post-install.sh",
             "Path": "{{.Machine.Path}}/post-install.sh",
-            "UUID": "net-post-install.sh.tmpl"
+            "ID": "net-post-install.sh.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/ubuntu-14.04.4.json
+++ b/embedded/assets/bootenvs/ubuntu-14.04.4.json
@@ -29,32 +29,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "seed",
             "Path": "{{.Machine.Path}}/seed",
-            "UUID": "net_seed.tmpl"
+            "ID": "net_seed.tmpl"
         },
         {
             "Name": "net-post-install.sh",
             "Path": "{{.Machine.Path}}/post-install.sh",
-            "UUID": "net-post-install.sh.tmpl"
+            "ID": "net-post-install.sh.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/ubuntu-14.04.json
+++ b/embedded/assets/bootenvs/ubuntu-14.04.json
@@ -29,32 +29,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "seed",
             "Path": "{{.Machine.Path}}/seed",
-            "UUID": "net_seed.tmpl"
+            "ID": "net_seed.tmpl"
         },
         {
             "Name": "net-post-install.sh",
             "Path": "{{.Machine.Path}}/post-install.sh",
-            "UUID": "net-post-install.sh.tmpl"
+            "ID": "net-post-install.sh.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/ubuntu-15.04.json
+++ b/embedded/assets/bootenvs/ubuntu-15.04.json
@@ -29,32 +29,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "seed",
             "Path": "{{.Machine.Path}}/seed",
-            "UUID": "net_seed.tmpl"
+            "ID": "net_seed.tmpl"
         },
         {
             "Name": "net-post-install.sh",
             "Path": "{{.Machine.Path}}/post-install.sh",
-            "UUID": "net-post-install.sh.tmpl"
+            "ID": "net-post-install.sh.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/ubuntu-16.04.json
+++ b/embedded/assets/bootenvs/ubuntu-16.04.json
@@ -29,32 +29,32 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "default-pxelinux.tmpl"
+            "ID": "default-pxelinux.tmpl"
         },
         {
             "Name": "elilo",
             "Path": "{{.Machine.HexAddress}}.conf",
-            "UUID": "default-elilo.tmpl"
+            "ID": "default-elilo.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "default-ipxe.tmpl"
+            "ID": "default-ipxe.tmpl"
         },
         {
             "Name": "seed",
             "Path": "{{.Machine.Path}}/seed",
-            "UUID": "net_seed.tmpl"
+            "ID": "net_seed.tmpl"
         },
         {
             "Name": "net-post-install.sh",
             "Path": "{{.Machine.Path}}/post-install.sh",
-            "UUID": "net-post-install.sh.tmpl"
+            "ID": "net-post-install.sh.tmpl"
         },
         {
             "Name": "rebar_join.sh",
             "Path": "{{.Machine.Path}}/rebar_join.sh",
-            "UUID": "rebar-join.sh.tmpl"
+            "ID": "rebar-join.sh.tmpl"
         }
     ]
 }

--- a/embedded/assets/bootenvs/windows-2012r2.json
+++ b/embedded/assets/bootenvs/windows-2012r2.json
@@ -25,22 +25,22 @@
         {
             "Name": "pxelinux",
             "Path": "pxelinux.cfg/{{.Machine.HexAddress}}",
-            "UUID": "windows.pxelinux.tmpl"
+            "ID": "windows.pxelinux.tmpl"
         },
         {
             "Name": "ipxe",
             "Path": "{{.Machine.Address}}.ipxe",
-            "UUID": "windows.ipxe.tmpl"
+            "ID": "windows.ipxe.tmpl"
         },
         {
             "Name": "start-install",
             "Path": "{{.Machine.Path}}/stage1.ps1",
-            "UUID": "stage1.cmd.tmpl"
+            "ID": "stage1.cmd.tmpl"
         },
         {
             "Name": "unattend.xml",
             "Path": "{{.Machine.Path}}/unattend.xml",
-            "UUID": "2012r2-unattend.xml.tmpl"
+            "ID": "2012r2-unattend.xml.tmpl"
         }
     ]
 }

--- a/test-data/vbox1.json
+++ b/test-data/vbox1.json
@@ -1,1 +1,17 @@
-{"Name":"vbox1","Subnet":"192.168.100.0/24","NextServer":"192.168.100.1","ActiveStart":"192.168.100.110","ActiveEnd":"192.168.100.200","ActiveLeaseTime":60,"ReservedLeaseTime":7200,"OnlyReservations":false,"Options":[{"Code":0,"Value":"string"}],"Strategy":"MAC"}
+{
+  "Name": "vbox1",
+  "Subnet": "192.168.100.0/24",
+  "NextServer": "192.168.100.1",
+  "ActiveStart": "192.168.100.110",
+  "ActiveEnd": "192.168.100.200",
+  "ActiveLeaseTime": 60,
+  "ReservedLeaseTime": 7200,
+  "OnlyReservations": false,
+  "Options": [
+    {
+      "Code": 0,
+      "Value": "string"
+    }
+  ],
+  "Strategy": "MAC"
+}


### PR DESCRIPTION
load default templates and bootenvs if not present already.
Pretty format the example subnet.