### PR TITLE
Make rscli understand yaml for input and output.

### DIFF
--- a/cli/bootenv.go
+++ b/cli/bootenv.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/VictorLowther/jsonpatch"
 	bootenvs "github.com/rackn/rocket-skates/client/boot_envs"
@@ -34,7 +35,7 @@ func addBootEnvCommands() (res *cobra.Command) {
 			if resp, err := session.BootEnvs.ListBootEnvs(bootenvs.NewListBootEnvsParams()); err != nil {
 				log.Fatalf("Error listing %v: %v", name, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -68,7 +69,7 @@ func addBootEnvCommands() (res *cobra.Command) {
 			if resp, err := session.BootEnvs.GetBootEnv(bootenvs.NewGetBootEnvParams().WithName(args[0])); err != nil {
 				log.Fatalf("Failed to fetch %v: %v\n%v\n", singularName, args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -107,14 +108,14 @@ func addBootEnvCommands() (res *cobra.Command) {
 				buf = []byte(args[0])
 			}
 			bootenv := &models.BootEnv{}
-			err = json.Unmarshal(buf, bootenv)
+			err = yaml.Unmarshal(buf, bootenv)
 			if err != nil {
 				log.Fatalf("Invalid %v object: %v\n", singularName, err)
 			}
 			if resp, err := session.BootEnvs.CreateBootEnv(bootenvs.NewCreateBootEnvParams().WithBody(bootenv)); err != nil {
 				log.Fatalf("Unable to create new %v: %v\n", singularName, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -140,7 +141,7 @@ func addBootEnvCommands() (res *cobra.Command) {
 					buf = []byte(args[1])
 				}
 				bootenv := resp.Payload
-				buf2, err := json.Marshal(bootenv)
+				buf2, err := yaml.Marshal(bootenv)
 				if err != nil {
 					log.Fatalf("Unable to marshal object: %v\n", err)
 				}
@@ -151,7 +152,7 @@ func addBootEnvCommands() (res *cobra.Command) {
 				}
 
 				bootenv = &models.BootEnv{}
-				err = json.Unmarshal(merged, bootenv)
+				err = yaml.Unmarshal(merged, bootenv)
 				if err != nil {
 					log.Fatalf("Unable to unmarshal merged object: %v\n", err)
 				}
@@ -159,7 +160,7 @@ func addBootEnvCommands() (res *cobra.Command) {
 				if resp, err := session.BootEnvs.PutBootEnv(bootenvs.NewPutBootEnvParams().WithName(args[0]).WithBody(bootenv)); err != nil {
 					log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 				} else {
-					fmt.Println(prettyJSON(resp.Payload))
+					fmt.Println(pretty(resp.Payload))
 				}
 			}
 		},
@@ -172,28 +173,28 @@ func addBootEnvCommands() (res *cobra.Command) {
 				log.Fatalf("%v requires 2 arguments\n", c.UseLine())
 			}
 			obj := &models.BootEnv{}
-			if err := json.Unmarshal([]byte(args[0]), obj); err != nil {
+			if err := yaml.Unmarshal([]byte(args[0]), obj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[0], err)
 			}
 			newObj := &models.BootEnv{}
-			json.Unmarshal([]byte(args[0]), newObj)
-			if err := json.Unmarshal([]byte(args[1]), newObj); err != nil {
+			yaml.Unmarshal([]byte(args[0]), newObj)
+			if err := yaml.Unmarshal([]byte(args[1]), newObj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[1], err)
 			}
-			newBuf, _ := json.Marshal(newObj)
+			newBuf, _ := yaml.Marshal(newObj)
 			patch, err := jsonpatch.GenerateJSON([]byte(args[0]), newBuf, true)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch\n%v\n", err)
 			}
 			p := []*models.JSONPatchOperation{}
-			err = json.Unmarshal(patch, p)
+			err = yaml.Unmarshal(patch, p)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch Object\n%v\n", err)
 			}
 			if resp, err := session.BootEnvs.PatchBootEnv(bootenvs.NewPatchBootEnvParams().WithName(*obj.Name).WithBody(p)); err != nil {
 				log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/files.go
+++ b/cli/files.go
@@ -26,7 +26,7 @@ func addFileCommands() (cmds *cobra.Command) {
 			if resp, err := session.Files.ListFiles(files.NewListFilesParams()); err != nil {
 				log.Fatalf("Error listing files: %v", err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -48,7 +48,7 @@ func addFileCommands() (cmds *cobra.Command) {
 			if resp, err := session.Files.UploadFile(params); err != nil {
 				log.Fatalf("Error uploading: %v", err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/interfaces.go
+++ b/cli/interfaces.go
@@ -30,7 +30,7 @@ func addInterfaceCommands() (res *cobra.Command) {
 			if resp, err := session.Interfaces.ListInterfaces(interfaces.NewListInterfacesParams()); err != nil {
 				log.Fatalf("Error listing %v: %v", name, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -64,7 +64,7 @@ func addInterfaceCommands() (res *cobra.Command) {
 			if resp, err := session.Interfaces.GetInterface(interfaces.NewGetInterfaceParams().WithName(args[0])); err != nil {
 				log.Fatalf("Failed to fetch %v: %v\n%v\n", singularName, args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/isos.go
+++ b/cli/isos.go
@@ -26,7 +26,7 @@ func addIsoCommands() (cmds *cobra.Command) {
 			if resp, err := session.Isos.ListIsos(isos.NewListIsosParams()); err != nil {
 				log.Fatalf("Error listing isos: %v", err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -48,7 +48,7 @@ func addIsoCommands() (cmds *cobra.Command) {
 			if resp, err := session.Isos.UploadIso(params); err != nil {
 				log.Fatalf("Error uploading: %v", err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/lease.go
+++ b/cli/lease.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/VictorLowther/jsonpatch"
 	"github.com/go-openapi/strfmt"
@@ -35,7 +36,7 @@ func addLeaseCommands() (res *cobra.Command) {
 			if resp, err := session.Leases.ListLeases(leases.NewListLeasesParams()); err != nil {
 				log.Fatalf("Error listing %v: %v", name, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -74,7 +75,7 @@ func addLeaseCommands() (res *cobra.Command) {
 			if resp, err := session.Leases.GetLease(leases.NewGetLeaseParams().WithAddress(s)); err != nil {
 				log.Fatalf("Failed to fetch %v: %v\n%v\n", singularName, args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -113,14 +114,14 @@ func addLeaseCommands() (res *cobra.Command) {
 				buf = []byte(args[0])
 			}
 			lease := &models.Lease{}
-			err = json.Unmarshal(buf, lease)
+			err = yaml.Unmarshal(buf, lease)
 			if err != nil {
 				log.Fatalf("Invalid %v object: %v\n", singularName, err)
 			}
 			if resp, err := session.Leases.CreateLease(leases.NewCreateLeaseParams().WithBody(lease)); err != nil {
 				log.Fatalf("Unable to create new %v: %v\n", singularName, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -151,7 +152,7 @@ func addLeaseCommands() (res *cobra.Command) {
 					buf = []byte(args[1])
 				}
 				lease := resp.Payload
-				buf2, err := json.Marshal(lease)
+				buf2, err := yaml.Marshal(lease)
 				if err != nil {
 					log.Fatalf("Unable to marshal object: %v\n", err)
 				}
@@ -162,7 +163,7 @@ func addLeaseCommands() (res *cobra.Command) {
 				}
 
 				lease = &models.Lease{}
-				err = json.Unmarshal(merged, lease)
+				err = yaml.Unmarshal(merged, lease)
 				if err != nil {
 					log.Fatalf("Unable to unmarshal merged object: %v\n", err)
 				}
@@ -170,7 +171,7 @@ func addLeaseCommands() (res *cobra.Command) {
 				if resp, err := session.Leases.PutLease(leases.NewPutLeaseParams().WithAddress(s).WithBody(lease)); err != nil {
 					log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 				} else {
-					fmt.Println(prettyJSON(resp.Payload))
+					fmt.Println(pretty(resp.Payload))
 				}
 			}
 		},
@@ -183,28 +184,28 @@ func addLeaseCommands() (res *cobra.Command) {
 				log.Fatalf("%v requires 2 arguments\n", c.UseLine())
 			}
 			obj := &models.Lease{}
-			if err := json.Unmarshal([]byte(args[0]), obj); err != nil {
+			if err := yaml.Unmarshal([]byte(args[0]), obj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[0], err)
 			}
 			newObj := &models.Lease{}
-			json.Unmarshal([]byte(args[0]), newObj)
-			if err := json.Unmarshal([]byte(args[1]), newObj); err != nil {
+			yaml.Unmarshal([]byte(args[0]), newObj)
+			if err := yaml.Unmarshal([]byte(args[1]), newObj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[1], err)
 			}
-			newBuf, _ := json.Marshal(newObj)
+			newBuf, _ := yaml.Marshal(newObj)
 			patch, err := jsonpatch.GenerateJSON([]byte(args[0]), newBuf, true)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch\n%v\n", err)
 			}
 			p := []*models.JSONPatchOperation{}
-			err = json.Unmarshal(patch, p)
+			err = yaml.Unmarshal(patch, p)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch Object\n%v\n", err)
 			}
 			if resp, err := session.Leases.PatchLease(leases.NewPatchLeaseParams().WithAddress(*obj.Addr).WithBody(p)); err != nil {
 				log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/machines.go
+++ b/cli/machines.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/VictorLowther/jsonpatch"
 	"github.com/rackn/rocket-skates/client/machines"
@@ -34,7 +35,7 @@ func addMachineCommands() (res *cobra.Command) {
 			if resp, err := session.Machines.ListMachines(machines.NewListMachinesParams()); err != nil {
 				log.Fatalf("Error listing %v: %v", name, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -68,7 +69,7 @@ func addMachineCommands() (res *cobra.Command) {
 			if resp, err := session.Machines.GetMachine(machines.NewGetMachineParams().WithName(args[0])); err != nil {
 				log.Fatalf("Failed to fetch %v: %v\n%v\n", singularName, args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -107,14 +108,14 @@ func addMachineCommands() (res *cobra.Command) {
 				buf = []byte(args[0])
 			}
 			machine := &models.Machine{}
-			err = json.Unmarshal(buf, machine)
+			err = yaml.Unmarshal(buf, machine)
 			if err != nil {
 				log.Fatalf("Invalid %v object: %v\n", singularName, err)
 			}
 			if resp, err := session.Machines.CreateMachine(machines.NewCreateMachineParams().WithBody(machine)); err != nil {
 				log.Fatalf("Unable to create new %v: %v\n", singularName, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -140,7 +141,7 @@ func addMachineCommands() (res *cobra.Command) {
 					buf = []byte(args[1])
 				}
 				machine := resp.Payload
-				buf2, err := json.Marshal(machine)
+				buf2, err := yaml.Marshal(machine)
 				if err != nil {
 					log.Fatalf("Unable to marshal object: %v\n", err)
 				}
@@ -151,7 +152,7 @@ func addMachineCommands() (res *cobra.Command) {
 				}
 
 				machine = &models.Machine{}
-				err = json.Unmarshal(merged, machine)
+				err = yaml.Unmarshal(merged, machine)
 				if err != nil {
 					log.Fatalf("Unable to unmarshal merged object: %v\n", err)
 				}
@@ -159,7 +160,7 @@ func addMachineCommands() (res *cobra.Command) {
 				if resp, err := session.Machines.PutMachine(machines.NewPutMachineParams().WithName(args[0]).WithBody(machine)); err != nil {
 					log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 				} else {
-					fmt.Println(prettyJSON(resp.Payload))
+					fmt.Println(pretty(resp.Payload))
 				}
 			}
 		},
@@ -172,28 +173,28 @@ func addMachineCommands() (res *cobra.Command) {
 				log.Fatalf("%v requires 2 arguments\n", c.UseLine())
 			}
 			obj := &models.Machine{}
-			if err := json.Unmarshal([]byte(args[0]), obj); err != nil {
+			if err := yaml.Unmarshal([]byte(args[0]), obj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[0], err)
 			}
 			newObj := &models.Machine{}
-			json.Unmarshal([]byte(args[0]), newObj)
-			if err := json.Unmarshal([]byte(args[1]), newObj); err != nil {
+			yaml.Unmarshal([]byte(args[0]), newObj)
+			if err := yaml.Unmarshal([]byte(args[1]), newObj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[1], err)
 			}
-			newBuf, _ := json.Marshal(newObj)
+			newBuf, _ := yaml.Marshal(newObj)
 			patch, err := jsonpatch.GenerateJSON([]byte(args[0]), newBuf, true)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch\n%v\n", err)
 			}
 			p := []*models.JSONPatchOperation{}
-			err = json.Unmarshal(patch, p)
+			err = yaml.Unmarshal(patch, p)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch Object\n%v\n", err)
 			}
 			if resp, err := session.Machines.PatchMachine(machines.NewPatchMachineParams().WithName(obj.Name.String()).WithBody(p)); err != nil {
 				log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/main.go
+++ b/cli/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ghodss/yaml"
+
 	"github.com/VictorLowther/jsonpatch/utils"
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
@@ -22,6 +24,7 @@ var (
 	debug              = false
 	endpoint           = "127.0.0.1:8092"
 	username, password string
+	format             = "json"
 	app                = &cobra.Command{
 		Use:   "rscli",
 		Short: "A CLI application for interacting with the Rocket-Skates API",
@@ -61,8 +64,17 @@ func d(msg string, args ...interface{}) {
 	}
 }
 
-func prettyJSON(o interface{}) (res string) {
-	buf, err := json.MarshalIndent(o, "", "  ")
+func pretty(o interface{}) (res string) {
+	var buf []byte
+	var err error
+	switch format {
+	case "json":
+		buf, err = json.MarshalIndent(o, "", "  ")
+	case "yaml":
+		buf, err = yaml.Marshal(o)
+	default:
+		log.Fatalf("Unknown pretty format %s", format)
+	}
 	if err != nil {
 		log.Fatalf("Failed to unmarshal returned object!")
 	}
@@ -96,6 +108,9 @@ func init() {
 	app.PersistentFlags().BoolVarP(&debug,
 		"debug", "d", false,
 		"Whether the CLI should run in debug mode")
+	app.PersistentFlags().StringVarP(&format,
+		"format", "F", "json",
+		`The serialzation we expect for output.  Can be "json" or "yaml"`)
 }
 
 func main() {

--- a/cli/reservation.go
+++ b/cli/reservation.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/VictorLowther/jsonpatch"
 	"github.com/go-openapi/strfmt"
@@ -35,7 +36,7 @@ func addReservationCommands() (res *cobra.Command) {
 			if resp, err := session.Reservations.ListReservations(reservations.NewListReservationsParams()); err != nil {
 				log.Fatalf("Error listing %v: %v", name, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -74,7 +75,7 @@ func addReservationCommands() (res *cobra.Command) {
 			if resp, err := session.Reservations.GetReservation(reservations.NewGetReservationParams().WithAddress(s)); err != nil {
 				log.Fatalf("Failed to fetch %v: %v\n%v\n", singularName, args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -113,14 +114,14 @@ func addReservationCommands() (res *cobra.Command) {
 				buf = []byte(args[0])
 			}
 			reservation := &models.Reservation{}
-			err = json.Unmarshal(buf, reservation)
+			err = yaml.Unmarshal(buf, reservation)
 			if err != nil {
 				log.Fatalf("Invalid %v object: %v\n", singularName, err)
 			}
 			if resp, err := session.Reservations.CreateReservation(reservations.NewCreateReservationParams().WithBody(reservation)); err != nil {
 				log.Fatalf("Unable to create new %v: %v\n", singularName, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -151,7 +152,7 @@ func addReservationCommands() (res *cobra.Command) {
 					buf = []byte(args[1])
 				}
 				reservation := resp.Payload
-				buf2, err := json.Marshal(reservation)
+				buf2, err := yaml.Marshal(reservation)
 				if err != nil {
 					log.Fatalf("Unable to marshal object: %v\n", err)
 				}
@@ -162,7 +163,7 @@ func addReservationCommands() (res *cobra.Command) {
 				}
 
 				reservation = &models.Reservation{}
-				err = json.Unmarshal(merged, reservation)
+				err = yaml.Unmarshal(merged, reservation)
 				if err != nil {
 					log.Fatalf("Unable to unmarshal merged object: %v\n", err)
 				}
@@ -170,7 +171,7 @@ func addReservationCommands() (res *cobra.Command) {
 				if resp, err := session.Reservations.PutReservation(reservations.NewPutReservationParams().WithAddress(s).WithBody(reservation)); err != nil {
 					log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 				} else {
-					fmt.Println(prettyJSON(resp.Payload))
+					fmt.Println(pretty(resp.Payload))
 				}
 			}
 		},
@@ -183,28 +184,28 @@ func addReservationCommands() (res *cobra.Command) {
 				log.Fatalf("%v requires 2 arguments\n", c.UseLine())
 			}
 			obj := &models.Reservation{}
-			if err := json.Unmarshal([]byte(args[0]), obj); err != nil {
+			if err := yaml.Unmarshal([]byte(args[0]), obj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[0], err)
 			}
 			newObj := &models.Reservation{}
-			json.Unmarshal([]byte(args[0]), newObj)
-			if err := json.Unmarshal([]byte(args[1]), newObj); err != nil {
+			yaml.Unmarshal([]byte(args[0]), newObj)
+			if err := yaml.Unmarshal([]byte(args[1]), newObj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[1], err)
 			}
-			newBuf, _ := json.Marshal(newObj)
+			newBuf, _ := yaml.Marshal(newObj)
 			patch, err := jsonpatch.GenerateJSON([]byte(args[0]), newBuf, true)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch\n%v\n", err)
 			}
 			p := []*models.JSONPatchOperation{}
-			err = json.Unmarshal(patch, p)
+			err = yaml.Unmarshal(patch, p)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch Object\n%v\n", err)
 			}
 			if resp, err := session.Reservations.PatchReservation(reservations.NewPatchReservationParams().WithAddress(*obj.Addr).WithBody(p)); err != nil {
 				log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/subnet.go
+++ b/cli/subnet.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/VictorLowther/jsonpatch"
 	"github.com/rackn/rocket-skates/client/subnets"
@@ -34,7 +35,7 @@ func addSubnetCommands() (res *cobra.Command) {
 			if resp, err := session.Subnets.ListSubnets(subnets.NewListSubnetsParams()); err != nil {
 				log.Fatalf("Error listing %v: %v", name, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -68,7 +69,7 @@ func addSubnetCommands() (res *cobra.Command) {
 			if resp, err := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(args[0])); err != nil {
 				log.Fatalf("Failed to fetch %v: %v\n%v\n", singularName, args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -107,14 +108,14 @@ func addSubnetCommands() (res *cobra.Command) {
 				buf = []byte(args[0])
 			}
 			subnet := &models.Subnet{}
-			err = json.Unmarshal(buf, subnet)
+			err = yaml.Unmarshal(buf, subnet)
 			if err != nil {
 				log.Fatalf("Invalid %v object: %v\n", singularName, err)
 			}
 			if resp, err := session.Subnets.CreateSubnet(subnets.NewCreateSubnetParams().WithBody(subnet)); err != nil {
 				log.Fatalf("Unable to create new %v: %v\n", singularName, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -140,7 +141,7 @@ func addSubnetCommands() (res *cobra.Command) {
 					buf = []byte(args[1])
 				}
 				subnet := resp.Payload
-				buf2, err := json.Marshal(subnet)
+				buf2, err := yaml.Marshal(subnet)
 				if err != nil {
 					log.Fatalf("Unable to marshal object: %v\n", err)
 				}
@@ -151,7 +152,7 @@ func addSubnetCommands() (res *cobra.Command) {
 				}
 
 				subnet = &models.Subnet{}
-				err = json.Unmarshal(merged, subnet)
+				err = yaml.Unmarshal(merged, subnet)
 				if err != nil {
 					log.Fatalf("Unable to unmarshal merged object: %v\n", err)
 				}
@@ -159,7 +160,7 @@ func addSubnetCommands() (res *cobra.Command) {
 				if resp, err := session.Subnets.PutSubnet(subnets.NewPutSubnetParams().WithName(args[0]).WithBody(subnet)); err != nil {
 					log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 				} else {
-					fmt.Println(prettyJSON(resp.Payload))
+					fmt.Println(pretty(resp.Payload))
 				}
 			}
 		},
@@ -172,28 +173,28 @@ func addSubnetCommands() (res *cobra.Command) {
 				log.Fatalf("%v requires 2 arguments\n", c.UseLine())
 			}
 			obj := &models.Subnet{}
-			if err := json.Unmarshal([]byte(args[0]), obj); err != nil {
+			if err := yaml.Unmarshal([]byte(args[0]), obj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[0], err)
 			}
 			newObj := &models.Subnet{}
-			json.Unmarshal([]byte(args[0]), newObj)
-			if err := json.Unmarshal([]byte(args[1]), newObj); err != nil {
+			yaml.Unmarshal([]byte(args[0]), newObj)
+			if err := yaml.Unmarshal([]byte(args[1]), newObj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[1], err)
 			}
-			newBuf, _ := json.Marshal(newObj)
+			newBuf, _ := yaml.Marshal(newObj)
 			patch, err := jsonpatch.GenerateJSON([]byte(args[0]), newBuf, true)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch\n%v\n", err)
 			}
 			p := []*models.JSONPatchOperation{}
-			err = json.Unmarshal(patch, p)
+			err = yaml.Unmarshal(patch, p)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch Object\n%v\n", err)
 			}
 			if resp, err := session.Subnets.PatchSubnet(subnets.NewPatchSubnetParams().WithName(*obj.Name).WithBody(p)); err != nil {
 				log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/template.go
+++ b/cli/template.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/VictorLowther/jsonpatch"
 	"github.com/rackn/rocket-skates/client/templates"
@@ -34,7 +35,7 @@ func addTemplateCommands() (res *cobra.Command) {
 			if resp, err := session.Templates.ListTemplates(templates.NewListTemplatesParams()); err != nil {
 				log.Fatalf("Error listing %v: %v", name, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -68,7 +69,7 @@ func addTemplateCommands() (res *cobra.Command) {
 			if resp, err := session.Templates.GetTemplate(templates.NewGetTemplateParams().WithName(args[0])); err != nil {
 				log.Fatalf("Failed to fetch %v: %v\n%v\n", singularName, args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -107,14 +108,14 @@ func addTemplateCommands() (res *cobra.Command) {
 				buf = []byte(args[0])
 			}
 			template := &models.Template{}
-			err = json.Unmarshal(buf, template)
+			err = yaml.Unmarshal(buf, template)
 			if err != nil {
 				log.Fatalf("Invalid %v object: %v\n", singularName, err)
 			}
 			if resp, err := session.Templates.CreateTemplate(templates.NewCreateTemplateParams().WithBody(template)); err != nil {
 				log.Fatalf("Unable to create new %v: %v\n", singularName, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -135,7 +136,7 @@ func addTemplateCommands() (res *cobra.Command) {
 			if resp, err := session.Templates.CreateTemplate(templates.NewCreateTemplateParams().WithBody(tmpl)); err != nil {
 				log.Fatalf("Unable to create new %v: %v\n", singularName, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -161,7 +162,7 @@ func addTemplateCommands() (res *cobra.Command) {
 					buf = []byte(args[1])
 				}
 				template := resp.Payload
-				buf2, err := json.Marshal(template)
+				buf2, err := yaml.Marshal(template)
 				if err != nil {
 					log.Fatalf("Unable to marshal object: %v\n", err)
 				}
@@ -172,7 +173,7 @@ func addTemplateCommands() (res *cobra.Command) {
 				}
 
 				template = &models.Template{}
-				err = json.Unmarshal(merged, template)
+				err = yaml.Unmarshal(merged, template)
 				if err != nil {
 					log.Fatalf("Unable to unmarshal merged object: %v\n", err)
 				}
@@ -180,7 +181,7 @@ func addTemplateCommands() (res *cobra.Command) {
 				if resp, err := session.Templates.PutTemplate(templates.NewPutTemplateParams().WithName(args[0]).WithBody(template)); err != nil {
 					log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 				} else {
-					fmt.Println(prettyJSON(resp.Payload))
+					fmt.Println(pretty(resp.Payload))
 				}
 			}
 		},
@@ -193,28 +194,28 @@ func addTemplateCommands() (res *cobra.Command) {
 				log.Fatalf("%v requires 2 arguments\n", c.UseLine())
 			}
 			obj := &models.Template{}
-			if err := json.Unmarshal([]byte(args[0]), obj); err != nil {
+			if err := yaml.Unmarshal([]byte(args[0]), obj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[0], err)
 			}
 			newObj := &models.Template{}
-			json.Unmarshal([]byte(args[0]), newObj)
-			if err := json.Unmarshal([]byte(args[1]), newObj); err != nil {
+			yaml.Unmarshal([]byte(args[0]), newObj)
+			if err := yaml.Unmarshal([]byte(args[1]), newObj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[1], err)
 			}
-			newBuf, _ := json.Marshal(newObj)
+			newBuf, _ := yaml.Marshal(newObj)
 			patch, err := jsonpatch.GenerateJSON([]byte(args[0]), newBuf, true)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch\n%v\n", err)
 			}
 			p := []*models.JSONPatchOperation{}
-			err = json.Unmarshal(patch, p)
+			err = yaml.Unmarshal(patch, p)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch Object\n%v\n", err)
 			}
 			if resp, err := session.Templates.PatchTemplate(templates.NewPatchTemplateParams().WithName(*obj.ID).WithBody(p)); err != nil {
 				log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/cli/user.go
+++ b/cli/user.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+
+	"github.com/ghodss/yaml"
 
 	"github.com/VictorLowther/jsonpatch"
 	"github.com/rackn/rocket-skates/client/users"
@@ -34,7 +35,7 @@ func addUserCommands() (res *cobra.Command) {
 			if resp, err := session.Users.ListUsers(users.NewListUsersParams()); err != nil {
 				log.Fatalf("Error listing %v: %v", name, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -68,7 +69,7 @@ func addUserCommands() (res *cobra.Command) {
 			if resp, err := session.Users.GetUser(users.NewGetUserParams().WithName(args[0])); err != nil {
 				log.Fatalf("Failed to fetch %v: %v\n%v\n", singularName, args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -107,14 +108,14 @@ func addUserCommands() (res *cobra.Command) {
 				buf = []byte(args[0])
 			}
 			user := &models.User{}
-			err = json.Unmarshal(buf, user)
+			err = yaml.Unmarshal(buf, user)
 			if err != nil {
 				log.Fatalf("Invalid %v object: %v\n", singularName, err)
 			}
 			if resp, err := session.Users.CreateUser(users.NewCreateUserParams().WithBody(user)); err != nil {
 				log.Fatalf("Unable to create new %v: %v\n", singularName, err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})
@@ -140,7 +141,7 @@ func addUserCommands() (res *cobra.Command) {
 					buf = []byte(args[1])
 				}
 				user := resp.Payload
-				buf2, err := json.Marshal(user)
+				buf2, err := yaml.Marshal(user)
 				if err != nil {
 					log.Fatalf("Unable to marshal object: %v\n", err)
 				}
@@ -151,7 +152,7 @@ func addUserCommands() (res *cobra.Command) {
 				}
 
 				user = &models.User{}
-				err = json.Unmarshal(merged, user)
+				err = yaml.Unmarshal(merged, user)
 				if err != nil {
 					log.Fatalf("Unable to unmarshal merged object: %v\n", err)
 				}
@@ -159,7 +160,7 @@ func addUserCommands() (res *cobra.Command) {
 				if resp, err := session.Users.PutUser(users.NewPutUserParams().WithName(args[0]).WithBody(user)); err != nil {
 					log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 				} else {
-					fmt.Println(prettyJSON(resp.Payload))
+					fmt.Println(pretty(resp.Payload))
 				}
 			}
 		},
@@ -172,28 +173,28 @@ func addUserCommands() (res *cobra.Command) {
 				log.Fatalf("%v requires 2 arguments\n", c.UseLine())
 			}
 			obj := &models.User{}
-			if err := json.Unmarshal([]byte(args[0]), obj); err != nil {
+			if err := yaml.Unmarshal([]byte(args[0]), obj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[0], err)
 			}
 			newObj := &models.User{}
-			json.Unmarshal([]byte(args[0]), newObj)
-			if err := json.Unmarshal([]byte(args[1]), newObj); err != nil {
+			yaml.Unmarshal([]byte(args[0]), newObj)
+			if err := yaml.Unmarshal([]byte(args[1]), newObj); err != nil {
 				log.Fatalf("Unable to parse %v JSON %v\nError: %v\n", c.UseLine(), args[1], err)
 			}
-			newBuf, _ := json.Marshal(newObj)
+			newBuf, _ := yaml.Marshal(newObj)
 			patch, err := jsonpatch.GenerateJSON([]byte(args[0]), newBuf, true)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch\n%v\n", err)
 			}
 			p := []*models.JSONPatchOperation{}
-			err = json.Unmarshal(patch, p)
+			err = yaml.Unmarshal(patch, p)
 			if err != nil {
 				log.Fatalf("Cannot generate JSON Patch Object\n%v\n", err)
 			}
 			if resp, err := session.Users.PatchUser(users.NewPatchUserParams().WithName(*obj.Name).WithBody(p)); err != nil {
 				log.Fatalf("Unable to patch %v\n%v\n", args[0], err)
 			} else {
-				fmt.Println(prettyJSON(resp.Payload))
+				fmt.Println(pretty(resp.Payload))
 			}
 		},
 	})

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8bf5eb57951a1f30ddcf774ec06ea31ed7565358d25f6b546b354a0d6dde77a6
-updated: 2017-03-10T14:35:11.202068145-06:00
+hash: 1c65ece5795139b4e4c7a6c1ef7f03f200e2e841c31f7cced85252ff00689a37
+updated: 2017-03-17T11:40:25.899265492-05:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: fdf19785fd3558d619ef81212f5edf1d6c2a5911
@@ -38,6 +38,8 @@ imports:
   version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
 - name: github.com/elithrar/simple-scrypt
   version: 2325946f714c95de4a6088202c402fbdfa64163b
+- name: github.com/ghodss/yaml
+  version: 04f313413ffd65ce25f2541bfd2b2ceec5c0908c
 - name: github.com/gin-gonic/gin
   version: e2212d40c62a98b388a5eb48ecbdcf88534688ba
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,6 +9,7 @@ import:
   version: v2
   repo: https://github.com/go-yaml/yaml
 - package: github.com/VictorLowther/jsonpatch
+- package: github.com/ghodss/yaml
 - package: github.com/digitalrebar/digitalrebar
   subpackages:
   - go/common/client


### PR DESCRIPTION
This will allow for embedded templates that don't require manually
escaping quite so many quotes and newlines.