### PR TITLE
Pass the server logger to all midlayers.

### DIFF
--- a/backend/dataTracker.go
+++ b/backend/dataTracker.go
@@ -95,11 +95,9 @@ func (dt *dtobjs) remove(idx int) {
 
 // DataTracker represents everything there is to know about acting as a dataTracker.
 type DataTracker struct {
-	useProvisioner bool
-	useDHCP        bool
-	FileRoot       string
-	CommandURL     string
-	OurAddress     string
+	FileRoot   string
+	CommandURL string
+	OurAddress string
 
 	FileURL string
 	ApiURL  string
@@ -150,22 +148,19 @@ func (p *DataTracker) loadData(refObjs []store.KeySaver) error {
 
 // Create a new DataTracker that will use passed store to save all operational data
 func NewDataTracker(backend store.SimpleStore,
-	useProvisioner, useDHCP bool,
 	fileRoot, commandURL, furl, aurl, addr string,
 	logger *log.Logger,
 	defaultPrefs map[string]string) *DataTracker {
 
 	res := &DataTracker{
-		useDHCP:        useDHCP,
-		useProvisioner: useProvisioner,
-		FileRoot:       fileRoot,
-		CommandURL:     commandURL,
-		FileURL:        furl,
-		ApiURL:         aurl,
-		OurAddress:     addr,
-		Logger:         logger,
-		backends:       map[string]store.SimpleStore{},
-		defaultPrefs:   defaultPrefs,
+		FileRoot:     fileRoot,
+		CommandURL:   commandURL,
+		FileURL:      furl,
+		ApiURL:       aurl,
+		OurAddress:   addr,
+		Logger:       logger,
+		backends:     map[string]store.SimpleStore{},
+		defaultPrefs: defaultPrefs,
 	}
 	objs := []store.KeySaver{
 		&Machine{p: res},
@@ -232,8 +227,6 @@ func (p *DataTracker) SetPrefs(prefs map[string]string) error {
 		return true
 	}
 	for name, val := range prefs {
-		log.Printf("Handling %v: %v", name, val)
-
 		switch name {
 		case "defaultBootEnv":
 			if benvCheck(name, val) && savePref(name, val) {

--- a/backend/dataTracker_test.go
+++ b/backend/dataTracker_test.go
@@ -68,7 +68,7 @@ func loadExample(dt *DataTracker, kind, p string) (bool, error) {
 }
 
 func mkDT(bs store.SimpleStore) *DataTracker {
-	dt := NewDataTracker(bs, true, true, tmpDir, "CURL", "FURL", "AURL", "127.0.0.1", log.New(os.Stdout, "dt", 0), map[string]string{"defaultBootEnv": "default"})
+	dt := NewDataTracker(bs, tmpDir, "CURL", "FURL", "AURL", "127.0.0.1", log.New(os.Stdout, "dt", 0), map[string]string{"defaultBootEnv": "default"})
 	return dt
 }
 

--- a/midlayer/static.go
+++ b/midlayer/static.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-func ServeStatic(listenAt, fsPath string) error {
+func ServeStatic(listenAt, fsPath string, logger *log.Logger) error {
 	conn, err := net.Listen("tcp", listenAt)
 	if err != nil {
 		return err
@@ -15,7 +15,7 @@ func ServeStatic(listenAt, fsPath string) error {
 	http.Handle("/", fs)
 	go func() {
 		if err := http.Serve(conn, nil); err != nil {
-			log.Fatalf("Static HTTP server error %v", err)
+			logger.Fatalf("Static HTTP server error %v", err)
 		}
 	}()
 	return nil

--- a/midlayer/static_test.go
+++ b/midlayer/static_test.go
@@ -2,7 +2,9 @@ package midlayer
 
 import (
 	"io/ioutil"
+	"log"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -10,7 +12,7 @@ import (
 
 func TestStaticFiles(t *testing.T) {
 
-	hh := ServeStatic(":3235235", ".")
+	hh := ServeStatic(":3235235", ".", log.New(os.Stderr, "", log.LstdFlags))
 	if hh != nil {
 		if hh.Error() != "listen tcp: address 3235235: invalid port" {
 			t.Errorf("Expected a different error: %v", hh.Error())
@@ -19,7 +21,7 @@ func TestStaticFiles(t *testing.T) {
 		t.Errorf("Should have returned an error")
 	}
 
-	go ServeStatic(":32134", ".")
+	go ServeStatic(":32134", ".", log.New(os.Stderr, "", log.LstdFlags))
 
 	response, err := http.Get("http://127.0.0.1:32134/dhcp.go")
 	count := 0

--- a/midlayer/tftp.go
+++ b/midlayer/tftp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pin/tftp"
 )
 
-func ServeTftp(listen, fileRoot string) error {
+func ServeTftp(listen, fileRoot string, logger *log.Logger) error {
 	a, err := net.ResolveUDPAddr("udp", listen)
 	if err != nil {
 		return err
@@ -26,13 +26,13 @@ func ServeTftp(listen, fileRoot string) error {
 		p = filepath.Clean(p)
 		if !strings.HasPrefix(p, fileRoot+string(filepath.Separator)) {
 			err := fmt.Errorf("Filename %s tries to escape root %s", filename, fileRoot)
-			log.Println(err)
+			logger.Println(err)
 			return err
 		}
-		log.Printf("Sending %s from %s", filename, p)
+		logger.Printf("Sending %s from %s", filename, p)
 		file, err := os.Open(p)
 		if err != nil {
-			log.Println(err)
+			logger.Println(err)
 			return err
 		}
 		if t, ok := rf.(tftp.OutgoingTransfer); ok {
@@ -42,10 +42,10 @@ func ServeTftp(listen, fileRoot string) error {
 		}
 		n, err := rf.ReadFrom(file)
 		if err != nil {
-			log.Println(err)
+			logger.Println(err)
 			return err
 		}
-		log.Printf("%d bytes sent\n", n)
+		logger.Printf("%d bytes sent\n", n)
 		return nil
 	}, nil)
 

--- a/midlayer/tftp_test.go
+++ b/midlayer/tftp_test.go
@@ -3,6 +3,7 @@ package midlayer
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -12,7 +13,7 @@ import (
 
 func TestTftpFiles(t *testing.T) {
 
-	hh := ServeTftp(":3235235", ".")
+	hh := ServeTftp(":3235235", ".", log.New(os.Stderr, "", log.LstdFlags))
 	if hh != nil {
 		if hh.Error() != "address 3235235: invalid port" {
 			t.Errorf("Expected a different error: %v", hh.Error())
@@ -21,7 +22,7 @@ func TestTftpFiles(t *testing.T) {
 		t.Errorf("Should have returned an error")
 	}
 
-	hh = ServeTftp("1.1.1.1:11112", ".")
+	hh = ServeTftp("1.1.1.1:11112", ".", log.New(os.Stderr, "", log.LstdFlags))
 	if hh != nil {
 		if !strings.Contains(hh.Error(), "listen udp 1.1.1.1:11112: bind: ") {
 			t.Errorf("Expected a different error: %v", hh.Error())
@@ -34,7 +35,7 @@ func TestTftpFiles(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	hh = ServeTftp("127.0.0.1:11112", dir)
+	hh = ServeTftp("127.0.0.1:11112", dir, log.New(os.Stderr, "", log.LstdFlags))
 	if hh != nil {
 		t.Errorf("Should not return an error: %v", hh)
 	} else {

--- a/server/server.go
+++ b/server/server.go
@@ -106,8 +106,6 @@ func Server(c_opts *ProgOpts) {
 	}
 
 	dt := backend.NewDataTracker(backendStore,
-		!c_opts.DisableProvisioner,
-		!c_opts.DisableDHCP,
 		c_opts.FileRoot,
 		c_opts.CommandURL,
 		fmt.Sprintf("http://%s:%d", c_opts.OurAddress, c_opts.StaticPort),
@@ -130,12 +128,12 @@ func Server(c_opts *ProgOpts) {
 	}
 	if !c_opts.DisableProvisioner {
 		logger.Printf("Starting TFTP server")
-		if err = midlayer.ServeTftp(fmt.Sprintf(":%d", c_opts.TftpPort), c_opts.FileRoot); err != nil {
+		if err = midlayer.ServeTftp(fmt.Sprintf(":%d", c_opts.TftpPort), c_opts.FileRoot, logger); err != nil {
 			logger.Fatalf("Error starting TFTP server: %v", err)
 		}
 
 		logger.Printf("Starting static file server")
-		if err = midlayer.ServeStatic(fmt.Sprintf(":%d", c_opts.StaticPort), c_opts.FileRoot); err != nil {
+		if err = midlayer.ServeStatic(fmt.Sprintf(":%d", c_opts.StaticPort), c_opts.FileRoot, logger); err != nil {
 			logger.Fatalf("Error starting static file server: %v", err)
 		}
 	}


### PR DESCRIPTION
Also, strip unused flags and their flag-setting code from the DataTracker