### PR TITLE
Add OnlyUnknown flag to BootEnv.

### DIFF
--- a/assets/bootenvs/discovery.yml
+++ b/assets/bootenvs/discovery.yml
@@ -1,12 +1,13 @@
 ---
 Name: discovery
 Description: "The boot environment to use to have unknown machines boot to Sledgehammer"
+OnlyUnknown: true
 OS:
   Name: "sledgehammer/708de8b878e3818b1c1bb598a56de968939f9d4b"
   IsoFile: "sledgehammer-708de8b878e3818b1c1bb598a56de968939f9d4b.tar"
   IsoUrl: "http://opencrowbar.s3-website-us-east-1.amazonaws.com/sledgehammer/708de8b878e3818b1c1bb598a56de968939f9d4b/sledgehammer-708de8b878e3818b1c1bb598a56de968939f9d4b.tar"
 Kernel: vmlinuz0
-Initrds: 
+Initrds:
   - "stage1.img"
 BootParams: "rootflags=loop root=live:/sledgehammer.iso rootfstype=auto ro liveimg rd_NO_LUKS rd_NO_MD rd_NO_DM provisioner.web={{.ProvisionerURL}} rs.api={{.ApiURL}}"
 Templates:

--- a/backend/dataTracker.go
+++ b/backend/dataTracker.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 
 	"github.com/VictorLowther/jsonpatch2"
-	"github.com/dgrijalva/jwt-go"
 	"github.com/digitalrebar/digitalrebar/go/common/store"
 	"github.com/digitalrebar/digitalrebar/go/rebar-api/api"
+	jwt "github.com/digitalrebar/digitalrebar/go/vendor_src/src/github.com/dgrijalva/jwt-go"
 )
 
 var (
@@ -21,6 +21,7 @@ var (
 		Name:        "ignore",
 		Description: "The boot environment you should use to have unknown machines boot off their local hard drive",
 		OS:          OsInfo{Name: "ignore"},
+		OnlyUnknown: true,
 		Templates: []TemplateInfo{
 			{
 				Name: "pxelinux",
@@ -323,12 +324,13 @@ func (p *DataTracker) Prefs() map[string]string {
 
 func (p *DataTracker) SetPrefs(prefs map[string]string) error {
 	err := &Error{}
-	benvCheck := func(name, val string) bool {
-		if be := p.load("bootenvs", val); be == nil {
+	benvCheck := func(name, val string) *BootEnv {
+		be := p.load("bootenvs", val)
+		if be == nil {
 			err.Errorf("%s: Bootenv %s does not exist", name, val)
-			return false
+			return nil
 		}
-		return true
+		return AsBootEnv(be)
 	}
 	savePref := func(name, val string) bool {
 		pref := &Pref{p: p, Name: name, Val: val}
@@ -341,11 +343,13 @@ func (p *DataTracker) SetPrefs(prefs map[string]string) error {
 	for name, val := range prefs {
 		switch name {
 		case "defaultBootEnv":
-			if benvCheck(name, val) && savePref(name, val) {
+			be := benvCheck(name, val)
+			if be != nil && !be.OnlyUnknown {
+				savePref(name, val)
 				p.defaultBootEnv = val
 			}
 		case "unknownBootEnv":
-			if benvCheck(name, val) && savePref(name, val) {
+			if benvCheck(name, val) != nil && savePref(name, val) {
 				err.Merge(p.RenderUnknown())
 			}
 		default:
@@ -369,6 +373,10 @@ func (p *DataTracker) RenderUnknown() error {
 	if !env.Available {
 		err.Messages = env.Errors
 		err.containsError = true
+		return err
+	}
+	if !env.OnlyUnknown {
+		err.Errorf("BootEnv %s cannot be used for the unknownBootEnv", env.Name)
 		return err
 	}
 	r := p.NewRenderData(nil, env)

--- a/backend/dataTracker.go
+++ b/backend/dataTracker.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 
 	"github.com/VictorLowther/jsonpatch2"
+	"github.com/dgrijalva/jwt-go"
 	"github.com/digitalrebar/digitalrebar/go/common/store"
 	"github.com/digitalrebar/digitalrebar/go/rebar-api/api"
-	jwt "github.com/digitalrebar/digitalrebar/go/vendor_src/src/github.com/dgrijalva/jwt-go"
 )
 
 var (

--- a/backend/machines.go
+++ b/backend/machines.go
@@ -132,6 +132,8 @@ func (n *Machine) BeforeSave() error {
 		env := AsBootEnv(b)
 		if !env.Available {
 			e.Errorf("Machine %s wants BootEnv %s, which is not available", n.UUID(), n.BootEnv)
+		} else if env.OnlyUnknown {
+			e.Errorf("BootEnv %s does not allow Machine assignments, it has the OnlyUnknown flag.", env.Name)
 		} else {
 			n.toRender = n.p.NewRenderData(n, env)
 		}

--- a/cli/bootenv_test.go
+++ b/cli/bootenv_test.go
@@ -21,6 +21,7 @@ var bootEnvDefaultListString string = `[
     "OS": {
       "Name": "ignore"
     },
+    "OnlyUnknown": true,
     "OptionalParams": null,
     "RequiredParams": null,
     "Templates": [
@@ -58,6 +59,7 @@ var bootEnvShowIgnoreString string = `{
   "OS": {
     "Name": "ignore"
   },
+  "OnlyUnknown": true,
   "OptionalParams": null,
   "RequiredParams": null,
   "Templates": [
@@ -105,6 +107,7 @@ var bootEnvCreateJohnString string = `{
   "OS": {
     "Name": ""
   },
+  "OnlyUnknown": false,
   "OptionalParams": null,
   "RequiredParams": null,
   "Templates": null
@@ -124,6 +127,7 @@ var bootEnvListBothEnvsString = `[
     "OS": {
       "Name": "ignore"
     },
+    "OnlyUnknown": true,
     "OptionalParams": null,
     "RequiredParams": null,
     "Templates": [
@@ -156,6 +160,7 @@ var bootEnvListBothEnvsString = `[
     "OS": {
       "Name": ""
     },
+    "OnlyUnknown": false,
     "OptionalParams": null,
     "RequiredParams": null,
     "Templates": null
@@ -183,6 +188,7 @@ var bootEnvUpdateJohnString string = `{
   "OS": {
     "Name": ""
   },
+  "OnlyUnknown": false,
   "OptionalParams": null,
   "RequiredParams": null,
   "Templates": null
@@ -208,6 +214,7 @@ var bootEnvPatchBaseString string = `{
   "OS": {
     "Name": ""
   },
+  "OnlyUnknown": false,
   "OptionalParams": null,
   "RequiredParams": null,
   "Templates": null
@@ -229,6 +236,7 @@ var bootEnvPatchJohnString string = `{
   "OS": {
     "Name": ""
   },
+  "OnlyUnknown": false,
   "OptionalParams": null,
   "RequiredParams": null,
   "Templates": null
@@ -246,6 +254,7 @@ var bootEnvPatchMissingBaseString string = `{
   "OS": {
     "Name": ""
   },
+  "OnlyUnknown": false,
   "OptionalParams": null,
   "RequiredParams": null,
   "Templates": null
@@ -262,7 +271,7 @@ var bootEnvInstallNoArgUsageString string = "Error: rscli bootenvs install [boot
 var bootEnvInstallTooManyArgUsageString string = "Error: rscli bootenvs install [bootenvFile] [isoPath] has Too many args\n"
 var bootEnvInstallBadBootEnvDirErrorString string = "Error: Error determining whether bootenvs dir exists: stat bootenvs: no such file or directory\n\n"
 var bootEnvInstallBootEnvDirIsFileErrorString string = "Error: bootenvs is not a directory\n\n"
-var bootEnvInstallNoSledgehammerErrorString string = "Error: No bootenv bootenvs/sledgehammer.yml\n\n"
+var bootEnvInstallNoSledgehammerErrorString string = "Error: No bootenv bootenvs/fredhammer.yml\n\n"
 var bootEnvInstallSledgehammerBadJsonErrorString string = "Error: Invalid bootenv object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.BootEnv\n\n\n"
 
 var bootEnvInstallSledgehammerSuccessWithErrorsString string = `RE:
@@ -287,13 +296,14 @@ var bootEnvInstallSledgehammerSuccessString string = `{
     "stage1.img"
   ],
   "Kernel": "vmlinuz0",
-  "Name": "sledgehammer",
+  "Name": "fredhammer",
   "OS": {
     "IsoFile": "sledgehammer-708de8b878e3818b1c1bb598a56de968939f9d4b.tar",
     "IsoSha256": "e094e066b24671c461c17482c6f071d78723275c48df70eb9d24125c89e99760",
     "IsoUrl": "http://127.0.0.1:10003/sledgehammer-708de8b878e3818b1c1bb598a56de968939f9d4b.tar",
     "Name": "sledgehammer/708de8b878e3818b1c1bb598a56de968939f9d4b"
   },
+  "OnlyUnknown": false,
   "OptionalParams": [
     "ntp_servers",
     "access_keys"
@@ -336,6 +346,7 @@ var bootEnvInstallLocalSuccessString string = `{
   "OS": {
     "Name": "local"
   },
+  "OnlyUnknown": false,
   "OptionalParams": null,
   "RequiredParams": null,
   "Templates": [
@@ -411,7 +422,7 @@ func TestBootEnvCli(t *testing.T) {
 
 		CliTest{true, true, []string{"bootenvs", "install"}, noStdinString, noContentString, bootEnvInstallNoArgUsageString},
 		CliTest{true, true, []string{"bootenvs", "install", "john", "john", "john2"}, noStdinString, noContentString, bootEnvInstallTooManyArgUsageString},
-		CliTest{false, true, []string{"bootenvs", "install", "sledgehammer"}, noStdinString, noContentString, bootEnvInstallBadBootEnvDirErrorString},
+		CliTest{false, true, []string{"bootenvs", "install", "fredhammer"}, noStdinString, noContentString, bootEnvInstallBadBootEnvDirErrorString},
 	}
 
 	for _, test := range tests {
@@ -425,7 +436,7 @@ func TestBootEnvCli(t *testing.T) {
 	}
 
 	tests = []CliTest{
-		CliTest{false, true, []string{"bootenvs", "install", "bootenvs/sledgehammer.yml"}, noStdinString, noContentString, bootEnvInstallBootEnvDirIsFileErrorString},
+		CliTest{false, true, []string{"bootenvs", "install", "bootenvs/fredhammer.yml"}, noStdinString, noContentString, bootEnvInstallBootEnvDirIsFileErrorString},
 	}
 	for _, test := range tests {
 		testCli(t, test)
@@ -437,18 +448,18 @@ func TestBootEnvCli(t *testing.T) {
 	}
 
 	tests = []CliTest{
-		CliTest{false, true, []string{"bootenvs", "install", "bootenvs/sledgehammer.yml"}, noStdinString, noContentString, bootEnvInstallNoSledgehammerErrorString},
+		CliTest{false, true, []string{"bootenvs", "install", "bootenvs/fredhammer.yml"}, noStdinString, noContentString, bootEnvInstallNoSledgehammerErrorString},
 	}
 	for _, test := range tests {
 		testCli(t, test)
 	}
 
-	if err := ioutil.WriteFile("bootenvs/sledgehammer.yml", []byte("TEST"), 0644); err != nil {
+	if err := ioutil.WriteFile("bootenvs/fredhammer.yml", []byte("TEST"), 0644); err != nil {
 		t.Errorf("Failed to create bootenvs file: %v\n", err)
 	}
 
 	tests = []CliTest{
-		CliTest{false, true, []string{"bootenvs", "install", "bootenvs/sledgehammer.yml"}, noStdinString, noContentString, bootEnvInstallSledgehammerBadJsonErrorString},
+		CliTest{false, true, []string{"bootenvs", "install", "bootenvs/fredhammer.yml"}, noStdinString, noContentString, bootEnvInstallSledgehammerBadJsonErrorString},
 	}
 	for _, test := range tests {
 		testCli(t, test)
@@ -456,19 +467,19 @@ func TestBootEnvCli(t *testing.T) {
 
 	midlayer.ServeStatic("127.0.0.1:10003", backend.NewFS("test-data", nil), nil)
 
-	os.RemoveAll("bootenvs/sledgehammer.yml")
+	os.RemoveAll("bootenvs/fredhammer.yml")
 	if err := os.MkdirAll("bootenvs", 0755); err != nil {
 		t.Errorf("Failed to create bootenvs dir: %v\n", err)
 	}
-	if err := os.Symlink("../test-data/sledgehammer.yml", "bootenvs/sledgehammer.yml"); err != nil {
-		t.Errorf("Failed to create link to sledgehammer.yml: %v\n", err)
+	if err := os.Symlink("../test-data/fredhammer.yml", "bootenvs/fredhammer.yml"); err != nil {
+		t.Errorf("Failed to create link to fredhammer.yml: %v\n", err)
 	}
 	if err := os.Symlink("../../assets/bootenvs/local.yml", "bootenvs/local.yml"); err != nil {
 		t.Errorf("Failed to create link to local.yml: %v\n", err)
 	}
 	tests = []CliTest{
-		CliTest{false, false, []string{"bootenvs", "install", "--skip-download", "bootenvs/sledgehammer.yml"}, noStdinString, bootEnvInstallSledgehammerSuccessWithErrorsString, noErrorString},
-		CliTest{false, false, []string{"bootenvs", "destroy", "sledgehammer"}, noStdinString, "Deleted bootenv sledgehammer\n", noErrorString},
+		CliTest{false, false, []string{"bootenvs", "install", "--skip-download", "bootenvs/fredhammer.yml"}, noStdinString, bootEnvInstallSledgehammerSuccessWithErrorsString, noErrorString},
+		CliTest{false, false, []string{"bootenvs", "destroy", "fredhammer"}, noStdinString, "Deleted bootenv fredhammer\n", noErrorString},
 	}
 	for _, test := range tests {
 		testCli(t, test)
@@ -476,7 +487,7 @@ func TestBootEnvCli(t *testing.T) {
 
 	installSkipDownloadIsos = false
 	tests = []CliTest{
-		CliTest{false, false, []string{"bootenvs", "install", "bootenvs/sledgehammer.yml"}, noStdinString, bootEnvInstallSledgehammerSuccessString, noErrorString},
+		CliTest{false, false, []string{"bootenvs", "install", "bootenvs/fredhammer.yml"}, noStdinString, bootEnvInstallSledgehammerSuccessString, noErrorString},
 		CliTest{false, true, []string{"bootenvs", "install", "bootenvs/local.yml"}, noStdinString, noContentString, bootEnvInstallLocalMissingTemplatesErrorString},
 	}
 	for _, test := range tests {
@@ -494,11 +505,11 @@ func TestBootEnvCli(t *testing.T) {
 	}
 	tests = []CliTest{
 		CliTest{false, false, []string{"bootenvs", "install", "bootenvs/local.yml", "ic"}, noStdinString, bootEnvInstallLocalSuccessString, noErrorString},
-		CliTest{false, false, []string{"bootenvs", "destroy", "sledgehammer"}, noStdinString, "Deleted bootenv sledgehammer\n", noErrorString},
-		CliTest{false, false, []string{"bootenvs", "install", "bootenvs/sledgehammer.yml"}, noStdinString, bootEnvInstallSledgehammerSuccessString, noErrorString},
+		CliTest{false, false, []string{"bootenvs", "destroy", "fredhammer"}, noStdinString, "Deleted bootenv fredhammer\n", noErrorString},
+		CliTest{false, false, []string{"bootenvs", "install", "bootenvs/fredhammer.yml"}, noStdinString, bootEnvInstallSledgehammerSuccessString, noErrorString},
 
 		// Clean up
-		CliTest{false, false, []string{"bootenvs", "destroy", "sledgehammer"}, noStdinString, "Deleted bootenv sledgehammer\n", noErrorString},
+		CliTest{false, false, []string{"bootenvs", "destroy", "fredhammer"}, noStdinString, "Deleted bootenv fredhammer\n", noErrorString},
 		CliTest{false, false, []string{"bootenvs", "destroy", "local"}, noStdinString, "Deleted bootenv local\n", noErrorString},
 		CliTest{false, false, []string{"templates", "destroy", "local-pxelinux.tmpl"}, noStdinString, "Deleted template local-pxelinux.tmpl\n", noErrorString},
 		CliTest{false, false, []string{"templates", "destroy", "local-elilo.tmpl"}, noStdinString, "Deleted template local-elilo.tmpl\n", noErrorString},

--- a/cli/common_test.go
+++ b/cli/common_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"log"
@@ -20,6 +21,7 @@ import (
 var (
 	tmpDir  string
 	running bool
+	myToken string
 )
 
 var noErrorString string = ``
@@ -104,7 +106,7 @@ func testCli(t *testing.T, test CliTest) {
 	// Add access args
 	args := test.args
 	if !hasE {
-		args = []string{"-E", "https://127.0.0.1:10001", "-U", "rocketskates", "-P", "r0cketsk8ts"}
+		args = []string{"-E", "https://127.0.0.1:10001", "-T", myToken}
 		for _, a := range test.args {
 			args = append(args, a)
 		}
@@ -303,6 +305,14 @@ func TestMain(m *testing.M) {
 	if count == 30 {
 		log.Printf("Server failed to start in time allowed")
 	} else {
+		req, _ = http.NewRequest("GET", "https://127.0.0.1:10001/api/v3/users/rocketskates/token", nil)
+		req.SetBasicAuth("rocketskates", "r0cketsk8ts")
+		resp, _ := client.Do(req)
+		var token map[string]string
+		buf, _ := ioutil.ReadAll(resp.Body)
+		json.Unmarshal(buf, &token)
+		myToken, _ = token["Token"]
+
 		ret = m.Run()
 	}
 

--- a/cli/common_test.go
+++ b/cli/common_test.go
@@ -190,6 +190,7 @@ var yamlTestString = `- Available: true
   Name: ignore
   OS:
     Name: ignore
+  OnlyUnknown: true
   OptionalParams: null
   RequiredParams: null
   Templates:
@@ -224,6 +225,7 @@ var jsonTestString = `[
     "OS": {
       "Name": "ignore"
     },
+    "OnlyUnknown": true,
     "OptionalParams": null,
     "RequiredParams": null,
     "Templates": [

--- a/cli/template_test.go
+++ b/cli/template_test.go
@@ -7,7 +7,21 @@ import (
 	"testing"
 )
 
-var templateDefaultListString string = "[]\n"
+var templateDefaultListString string = `[
+  {
+    "Contents": "exit\n",
+    "ID": "local-elilo.tmpl"
+  },
+  {
+    "Contents": "#!ipxe\nexit",
+    "ID": "local-ipxe.tmpl"
+  },
+  {
+    "Contents": "DEFAULT local\nPROMPT 0\nTIMEOUT 10\nLABEL local\nlocalboot 0\n",
+    "ID": "local-pxelinux.tmpl"
+  }
+]
+`
 
 var templateShowNoArgErrorString string = "Error: rscli templates show [id] requires 1 argument\n"
 var templateShowTooManyArgErrorString string = "Error: rscli templates show [id] requires 1 argument\n"
@@ -43,6 +57,18 @@ var templateListBothEnvsString = `[
   {
     "Contents": "John Rules",
     "ID": "john"
+  },
+  {
+    "Contents": "exit\n",
+    "ID": "local-elilo.tmpl"
+  },
+  {
+    "Contents": "#!ipxe\nexit",
+    "ID": "local-ipxe.tmpl"
+  },
+  {
+    "Contents": "DEFAULT local\nPROMPT 0\nTIMEOUT 10\nLABEL local\nlocalboot 0\n",
+    "ID": "local-pxelinux.tmpl"
   }
 ]
 `

--- a/cli/test-data/fredhammer.yml
+++ b/cli/test-data/fredhammer.yml
@@ -1,5 +1,5 @@
 ---
-Name: "sledgehammer"
+Name: "fredhammer"
 OS:
   Name: "sledgehammer/708de8b878e3818b1c1bb598a56de968939f9d4b"
   IsoFile: "sledgehammer-708de8b878e3818b1c1bb598a56de968939f9d4b.tar"

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,6 +21,7 @@ import:
   subpackages:
   - api
 - package: github.com/jessevdk/go-flags
+- package: github.com/dgrijalva/jwt-go
 - package: github.com/pin/tftp
 - package: github.com/pborman/uuid
 - package: github.com/tylerb/graceful


### PR DESCRIPTION
This flag indicates that the BootEnv can only be used to render
default boot templates, and that individual machines cannot be
assigned to it.