### PR TITLE
Refactor tokens to support multiple claims

### DIFF
--- a/backend/dataTracker.go
+++ b/backend/dataTracker.go
@@ -678,7 +678,11 @@ func (p *DataTracker) Save(ref store.KeySaver) (store.KeySaver, error) {
 func (p *DataTracker) GetToken(tokenString string) (*DrpCustomClaims, error) {
 	return p.tokenManager.get(tokenString)
 }
+
+func (p *DataTracker) SealClaims(claims *DrpCustomClaims) (string, error) {
+	return claims.Seal(p.tokenManager)
+}
+
 func (p *DataTracker) NewToken(id string, ttl int, scope, action, specific string) (string, error) {
-	t := p.tokenManager.newToken(id, ttl, scope, action, specific)
-	return p.tokenManager.sign(t)
+	return NewClaim(id, ttl).Add(scope, action, specific).Seal(p.tokenManager)
 }

--- a/backend/dataTracker_test.go
+++ b/backend/dataTracker_test.go
@@ -186,14 +186,8 @@ func TestBackingStorePersistence(t *testing.T) {
 		if drpClaim.Id != "fred" {
 			t.Errorf("Claim ID doesn't match: %v %v\n", "fred", drpClaim.Id)
 		}
-		if drpClaim.Scope != "all" {
-			t.Errorf("Claim Scope doesn't match: %v %v\n", "all", drpClaim.Scope)
-		}
-		if drpClaim.Action != "a" {
-			t.Errorf("Claim Action doesn't match: %v %v\n", "m", drpClaim.Action)
-		}
-		if drpClaim.Specific != "m" {
-			t.Errorf("Claim Specific doesn't match: %v %v\n", "m", drpClaim.Specific)
+		if !drpClaim.Match("all", "a", "m") {
+			t.Errorf("Claim doesn't match: %v %#v\n", []string{"all", "a", "m"}, drpClaim)
 		}
 	}
 }

--- a/backend/jwt_utils_test.go
+++ b/backend/jwt_utils_test.go
@@ -34,8 +34,7 @@ func TestJWTUtils(t *testing.T) {
 	}
 
 	jwtManager = NewJwtManager([]byte(randString(32)))
-	tok := jwtManager.newToken("fred", 30, "all", "a", "m")
-	s, e := jwtManager.sign(tok)
+	s, e := NewClaim("fred", 30).Add("*", "a", "m").Seal(jwtManager)
 	if e != nil {
 		t.Errorf("Failed to sign token: %v\n", e)
 	}
@@ -46,19 +45,12 @@ func TestJWTUtils(t *testing.T) {
 		if drpClaim.Id != "fred" {
 			t.Errorf("Claim ID doesn't match: %v %v\n", "fred", drpClaim.Id)
 		}
-		if drpClaim.Scope != "all" {
-			t.Errorf("Claim Scope doesn't match: %v %v\n", "all", drpClaim.Scope)
-		}
-		if drpClaim.Action != "a" {
-			t.Errorf("Claim Action doesn't match: %v %v\n", "a", drpClaim.Action)
-		}
-		if drpClaim.Specific != "m" {
-			t.Errorf("Claim Specific doesn't match: %v %v\n", "m", drpClaim.Specific)
+		if !drpClaim.Match("all", "a", "m") {
+			t.Errorf("Claim Scope doesn't match: %v %v\n", []string{"all", "a", "m"}, drpClaim)
 		}
 	}
 
-	tok = jwtManager.newToken("fred", 1, "all", "m", "a")
-	s, e = jwtManager.sign(tok)
+	s, e = NewClaim("fred", 1).Add("*", "m", "a").Seal(jwtManager)
 	if e != nil {
 		t.Errorf("Failed to sign token: %v\n", e)
 	}

--- a/frontend/frontend_test.go
+++ b/frontend/frontend_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/VictorLowther/jsonpatch2"
-	"github.com/dgrijalva/jwt-go"
 	"github.com/digitalrebar/digitalrebar/go/common/store"
 	"github.com/gin-gonic/gin"
 	"github.com/rackn/rocket-skates/backend"
@@ -88,16 +87,7 @@ func (dt *LocalDTI) SetPrefs(prefs map[string]string) error {
 }
 
 func (dt *LocalDTI) GetToken(ets string) (*backend.DrpCustomClaims, error) {
-	t := &backend.DrpCustomClaims{
-		"all",
-		"",
-		"",
-		jwt.StandardClaims{
-			Issuer: "digitalrebar provision",
-			Id:     "rocketskates",
-		},
-	}
-	return t, nil
+	return backend.NewClaim("rocketskates", 30).Add("*", "*", "*"), nil
 }
 func (dt *LocalDTI) NewToken(id string, ttl int, s string, m string, a string) (string, error) {
 	return dt.TokenValue, dt.TokenError

--- a/frontend/users.go
+++ b/frontend/users.go
@@ -166,10 +166,16 @@ func (f *Frontend) InitUserApi() {
 			}
 			scope, _ := c.GetQuery("scope")
 			if scope == "" {
-				scope = "all"
+				scope = "*"
 			}
 			action, _ := c.GetQuery("action")
+			if action == "" {
+				action = "*"
+			}
 			specific, _ := c.GetQuery("specific")
+			if specific == "" {
+				specific = "*"
+			}
 
 			if t, err := f.dt.NewToken(c.Param(`name`), ttl, scope, action, specific); err != nil {
 				ne, ok := err.(*backend.Error)


### PR DESCRIPTION
This allows for more complex tokens to be created for specific
actions, and can eventually allow mapping tokens to user capability
sets.