### PR TITLE
Add a generateToken method that "knows" when to create

### DIFF
--- a/assets/bootenvs/discovery.yml
+++ b/assets/bootenvs/discovery.yml
@@ -85,12 +85,13 @@ Templates:
           chmod 755 /usr/bin/rscli
       fi
 
+      # This will contain a token appropriate for the path being
+      # used below.  Either a create or update/show token
+      export RS_TOKEN="{{.GenerateToken}}"
+
       # See if we have already been created.
       if [[ $(cat /proc/cmdline) =~ $host_re ]]; then
           RS_UUID="${BASH_REMATCH[1]}"
-          if ! [[ $RS_UUID =~ $uuid_re ]]; then
-              RS_UUID="$(rscli machines show "$RS_UUID" |jq -r '.Uuid')"
-          fi
           # If we did not get a hostname from DHCP, get it from RocketSkates.
           if [[ ! $HOSTNAME ]]; then
               HOSTNAME="$(rscli machines show "$RS_UUID" |jq -r '.Name')"

--- a/assets/bootenvs/sledgehammer.yml
+++ b/assets/bootenvs/sledgehammer.yml
@@ -1,4 +1,7 @@
 ---
+# Sledgehammer (the per machine bootenv)
+# This bootenv requires the start-up.sh file to be rendered by the discovery bootenv.
+# These two bootenvs are linked and should be used as a pair.
 Name: "sledgehammer"
 OS:
   Name: "sledgehammer/708de8b878e3818b1c1bb598a56de968939f9d4b"

--- a/assets/templates/centos-6.ks.tmpl
+++ b/assets/templates/centos-6.ks.tmpl
@@ -100,6 +100,9 @@ sed -i -e '/initdefault/ s/5/3/' /etc/inittab
 # Tell rocket skates we are done
 (cd /bin; curl -s -f -L -o rscli "{{.ProvisionerURL}}/files/rscli.amd64.linux"; chmod 755 rscli)
 export RS_ENDPOINT="{{.ApiURL}}"
+# This will contain a token appropriate for the path being
+# used below.  Either a create or update/show token
+export RS_TOKEN="{{.GenerateToken}}"
 rscli machines update "{{.Machine.UUID}}" '{"BootEnv": "local"}'
 
 sync

--- a/assets/templates/centos-7.ks.tmpl
+++ b/assets/templates/centos-7.ks.tmpl
@@ -95,6 +95,9 @@ echo "no_proxy=127.0.0.1,localhost,::1,{{index (.Param "proxy-servers") 0 "addre
 # Tell rocket skates we are done
 (cd /bin; curl -s -f -L -o rscli "{{.ProvisionerURL}}/files/rscli.amd64.linux"; chmod 755 rscli)
 export RS_ENDPOINT="{{.ApiURL}}"
+# This will contain a token appropriate for the path being
+# used below.  Either a create or update/show token
+export RS_TOKEN="{{.GenerateToken}}"
 rscli machines update "{{.Machine.UUID}}" '{"BootEnv": "local"}'
 
 sync

--- a/assets/templates/net-post-install.sh.tmpl
+++ b/assets/templates/net-post-install.sh.tmpl
@@ -75,6 +75,9 @@ export HOSTNAME
 # Tell rocket skates we are done
 (cd /bin; curl -s -f -L -o rscli "{{.ProvisionerURL}}/files/rscli.amd64.linux"; chmod 755 rscli)
 export RS_ENDPOINT="{{.ApiURL}}"
+# This will contain a token appropriate for the path being
+# used below.  Either a create or update/show token
+export RS_TOKEN="{{.GenerateToken}}"
 rscli machines update "{{.Machine.UUID}}" '{"BootEnv": "local"}'
 
 EOF

--- a/backend/dataTracker.go
+++ b/backend/dataTracker.go
@@ -332,6 +332,14 @@ func (p *DataTracker) SetPrefs(prefs map[string]string) error {
 		}
 		return AsBootEnv(be)
 	}
+	intCheck := func(name, val string) bool {
+		_, e := strconv.Atoi(val)
+		if e == nil {
+			return true
+		}
+		err.Errorf("%s: %s", name, e.Error())
+		return false
+	}
 	savePref := func(name, val string) bool {
 		pref := &Pref{p: p, Name: name, Val: val}
 		if _, saveErr := p.save(pref); saveErr != nil {
@@ -352,6 +360,16 @@ func (p *DataTracker) SetPrefs(prefs map[string]string) error {
 			if benvCheck(name, val) != nil && savePref(name, val) {
 				err.Merge(p.RenderUnknown())
 			}
+		case "unknownTokenTimeout":
+			if intCheck(name, val) {
+				savePref(name, val)
+			}
+			continue
+		case "knownTokenTimeout":
+			if intCheck(name, val) {
+				savePref(name, val)
+			}
+			continue
 		default:
 			err.Errorf("Unknown preference %s", name)
 		}

--- a/backend/renderData.go
+++ b/backend/renderData.go
@@ -113,6 +113,18 @@ func (r *RenderData) ApiURL() string {
 	return r.p.ApiURL(r.remoteIP)
 }
 
+func (r *RenderData) GenerateToken() string {
+	var t string
+	if r.Machine == nil {
+		t, _ = NewClaim("general", 10*60).Add("machines", "post", "*").
+			Add("machines", "get", "*").Seal(r.p.tokenManager)
+	} else {
+		t, _ = NewClaim(r.Machine.Key(), 10*60).Add("machines", "patch", r.Machine.Key()).
+			Add("machines", "get", r.Machine.Key()).Seal(r.p.tokenManager)
+	}
+	return t
+}
+
 // BootParams is a helper function that expands the BootParams
 // template from the boot environment.
 func (r *RenderData) BootParams() (string, error) {

--- a/backend/renderData.go
+++ b/backend/renderData.go
@@ -168,12 +168,11 @@ func (r *RenderData) ParseUrl(segment, rawUrl string) (string, error) {
 
 // ParamExists is a helper function for determining the existence of a machine parameter.
 func (r *RenderData) ParamExists(key string) bool {
-	if r.Machine == nil {
-		return false
-	}
-	_, ok := r.Machine.Params[key]
-	if ok {
-		return ok
+	if r.Machine != nil {
+		_, ok := r.Machine.Params[key]
+		if ok {
+			return ok
+		}
 	}
 	param := r.p.load("parameters", key)
 	if param != nil {
@@ -184,12 +183,11 @@ func (r *RenderData) ParamExists(key string) bool {
 
 // Param is a helper function for extracting a parameter from Machine.Params
 func (r *RenderData) Param(key string) (interface{}, error) {
-	if r.Machine == nil {
-		return nil, fmt.Errorf("Missing machine")
-	}
-	res, ok := r.Machine.Params[key]
-	if ok {
-		return res, nil
+	if r.Machine != nil {
+		res, ok := r.Machine.Params[key]
+		if ok {
+			return res, nil
+		}
 	}
 	param := r.p.load("parameters", key)
 	if param != nil {

--- a/backend/renderData_test.go
+++ b/backend/renderData_test.go
@@ -191,14 +191,32 @@ func TestRenderData(t *testing.T) {
 	// Test other functions - without a machine or env
 	_, e = rd.Param("bogus")
 	if e == nil {
-		t.Errorf("Param should return an error when machine is not defined in RenderData\n")
-	} else if e.Error() != "Missing machine" {
-		t.Errorf("Param should return an error: Missing machine, but returned: %s\n", e.Error())
+		t.Errorf("Param should return an error when machine is not and not global defined in RenderData\n")
+	} else if e.Error() != "No such machine parameter bogus" {
+		t.Errorf("Param should return an error: No such machine parameter bogus, but returned: %s\n", e.Error())
 	}
 	ok := rd.ParamExists("bogus")
 	if ok {
-		t.Errorf("ParamExists should return false when machine is not defined in RenderData\n")
+		t.Errorf("ParamExists should return false when machine is not defined and not global in RenderData\n")
 	}
+	// Test global parameter
+	d, e := rd.Param("test")
+	if e != nil {
+		t.Errorf("Param test should NOT return an error: %v\n", e)
+	}
+	s, ok = d.(string)
+	if !ok {
+		t.Errorf("Parameter test should have been a string\n")
+	} else {
+		if s != "foreal" {
+			t.Errorf("Parameter test should have been foreal: %s\n", s)
+		}
+	}
+	ok = rd.ParamExists("test")
+	if !ok {
+		t.Errorf("ParamExists test should return true when machine has foo defined in RenderData\n")
+	}
+
 	s, e = rd.BootParams()
 	if e == nil {
 		t.Errorf("BootParams with no ENV should have generated an error\n")
@@ -255,7 +273,7 @@ func TestRenderData(t *testing.T) {
 	}
 
 	// Test machine parameter
-	d, e := rd.Param("foo")
+	d, e = rd.Param("foo")
 	if e != nil {
 		t.Errorf("Param foo should NOT return an error: %v\n", e)
 	}

--- a/backend/renderData_test.go
+++ b/backend/renderData_test.go
@@ -25,6 +25,7 @@ Name = {{.Env.Name}}
 RenderData:
 ProvisionerAddress = {{.ProvisionerAddress}}
 ProvisionerURL = {{.ProvisionerURL}}
+ApiURL = {{.ApiURL}}
 CommandURL = {{.CommandURL}}
 BootParams = {{.BootParams}}`
 	tmplDefaultRenderedWithoutFred = `Machine: 
@@ -41,6 +42,7 @@ Name = default
 RenderData:
 ProvisionerAddress = 127.0.0.1
 ProvisionerURL = http://127.0.0.1:8091
+ApiURL = https://127.0.0.1:8092
 CommandURL = CURL
 BootParams = default`
 	tmplDefaultRenderedWithFred = `Machine: 
@@ -57,6 +59,7 @@ fred = fred
 RenderData:
 ProvisionerAddress = 127.0.0.1
 ProvisionerURL = http://127.0.0.1:8091
+ApiURL = https://127.0.0.1:8092
 CommandURL = CURL
 BootParams = default`
 	tmplNothing = `Nothing`
@@ -65,11 +68,20 @@ BootParams = default`
 func TestRenderData(t *testing.T) {
 	bs := store.NewSimpleMemoryStore()
 	dt := mkDT(bs)
+
+	defaultBootEnv := &BootEnv{p: dt, Name: "default", Templates: []TemplateInfo{{Name: "ipxe", Path: "machines/{{.Machine.UUID}}/file", ID: "default"}}, BootParams: "{{.Env.Name}}"}
+	nothingBootEnv := &BootEnv{p: dt, Name: "nothing", Templates: []TemplateInfo{{Name: "ipxe", Path: "machines/{{.Machine.UUID}}/file", ID: "nothing"}}, BootParams: "{{.Env.Name}}"}
+	badBootEnv := &BootEnv{p: dt, Name: "bad", Templates: []TemplateInfo{{Name: "ipxe", Path: "machines/{{.Machine.UUID}}/file", ID: "nothing"}}, BootParams: "{{.Param \"cow\"}}"}
+
 	objs := []crudTest{
+		{"Create test parameter with no value", dt.create, &Param{Name: "test"}, true},
+		{"Update test with a value", dt.update, &Param{Name: "test", Value: "foreal"}, true},
+
 		{"Create default template", dt.create, &Template{p: dt, ID: "default", Contents: tmplDefault}, true},
 		{"Create nothing template", dt.create, &Template{p: dt, ID: "nothing", Contents: tmplNothing}, true},
-		{"Create default bootenv", dt.create, &BootEnv{p: dt, Name: "default", Templates: []TemplateInfo{{Name: "ipxe", Path: "machines/{{.Machine.UUID}}/file", ID: "default"}}, BootParams: "{{.Env.Name}}"}, true},
-		{"Create nothing bootenv", dt.create, &BootEnv{p: dt, Name: "nothing", Templates: []TemplateInfo{{Name: "ipxe", Path: "machines/{{.Machine.UUID}}/file", ID: "nothing"}}, BootParams: "{{.Env.Name}}"}, true},
+		{"Create default bootenv", dt.create, defaultBootEnv, true},
+		{"Create nothing bootenv", dt.create, nothingBootEnv, true},
+		{"Create bad bootenv", dt.create, badBootEnv, true},
 	}
 	for _, obj := range objs {
 		obj.Test(t)
@@ -137,4 +149,203 @@ func TestRenderData(t *testing.T) {
 	} else {
 		t.Logf("BootEnv nothing rendered properly for test machine")
 	}
+
+	// Test the render functions directly.
+	rd := dt.NewRenderData(nil, nil)
+
+	// Test ParseUrl - independent of Machine and Env
+	s, e := rd.ParseUrl("scheme", "http://192.168.0.%31:8080/")
+	if e == nil {
+		t.Errorf("ParseUrl with bad URL should have generated an error\n")
+	} else if e.Error() != "parse http://192.168.0.%31:8080/: invalid URL escape \"%31\"" {
+		t.Errorf("ParseUrl with bad URL should have generated an error: %s, but got %s\n", "parse http://192.168.0.%31:8080/: invalid URL escape \"%31\"", e.Error())
+	}
+	s, e = rd.ParseUrl("bogus", "https://fred/path/apt")
+	if e == nil {
+		t.Errorf("ParseUrl with bad segment should have generated an error\n")
+	} else if e.Error() != "No idea how to get URL part bogus from https://fred/path/apt" {
+		t.Errorf("ParseUrl with bad segment should have generated an error: %s, but got %s\n", "No idea how to get URL part bogus from https://fred/path/apt", e.Error())
+	}
+	s, e = rd.ParseUrl("scheme", "https://fred/path/apt")
+	if e != nil {
+		t.Errorf("ParseUrl with scheme segment should NOT have generated an error: %v\n", e)
+	}
+	if s != "https" {
+		t.Errorf("ParseUrl with scheme segment found incorrect scheme: %s, %s\n", "https", s)
+	}
+	s, e = rd.ParseUrl("host", "https://fred/path/apt")
+	if e != nil {
+		t.Errorf("ParseUrl with host segment should NOT have generated an error: %v\n", e)
+	}
+	if s != "fred" {
+		t.Errorf("ParseUrl with host segment found incorrect host: %s, %s\n", "fred", s)
+	}
+	s, e = rd.ParseUrl("path", "https://fred/path/apt")
+	if e != nil {
+		t.Errorf("ParseUrl with path segment should NOT have generated an error: %v\n", e)
+	}
+	if s != "/path/apt" {
+		t.Errorf("ParseUrl with path segment found incorrect path: %s, %s\n", "/path/apt", s)
+	}
+
+	// Test other functions - without a machine or env
+	_, e = rd.Param("bogus")
+	if e == nil {
+		t.Errorf("Param should return an error when machine is not defined in RenderData\n")
+	} else if e.Error() != "Missing machine" {
+		t.Errorf("Param should return an error: Missing machine, but returned: %s\n", e.Error())
+	}
+	ok := rd.ParamExists("bogus")
+	if ok {
+		t.Errorf("ParamExists should return false when machine is not defined in RenderData\n")
+	}
+	s, e = rd.BootParams()
+	if e == nil {
+		t.Errorf("BootParams with no ENV should have generated an error\n")
+	} else if e.Error() != "Missing bootenv" {
+		t.Errorf("BootParams with no ENV should have generated an error: %s, but got %s\n", "Missing bootenv", e.Error())
+	}
+	s = rd.GenerateToken()
+	claim, e := dt.GetToken(s)
+	if e != nil {
+		t.Errorf("GetToken should return a good claim. %v\n", e)
+	}
+	if !claim.Match("machines", "post", "anything") {
+		t.Errorf("Unknown token should match: machines/post/*\n")
+	}
+	if !claim.Match("machines", "get", "anything") {
+		t.Errorf("Unknown token should match: machines/post/*\n")
+	}
+	if claim.ExpiresAt-claim.IssuedAt != 600 {
+		t.Errorf("Unknown token timeout should be 600, but was %v\n", claim.ExpiresAt-claim.IssuedAt)
+	}
+	e = dt.SetPrefs(map[string]string{"unknownTokenTimeout": "50"})
+	if e != nil {
+		t.Errorf("SetPrefs should not return an error: %v\n", e)
+	}
+	s = rd.GenerateToken()
+	claim, e = dt.GetToken(s)
+	if e != nil {
+		t.Errorf("GetToken should return a good claim. %v\n", e)
+	}
+	if !claim.Match("machines", "post", "anything") {
+		t.Errorf("Unknown token should match: machines/post/*\n")
+	}
+	if !claim.Match("machines", "get", "anything") {
+		t.Errorf("Unknown token should match: machines/post/*\n")
+	}
+	if claim.Match("machines", "patch", "anything") {
+		t.Errorf("Unknown token should NOT match: machines/patch/*\n")
+	}
+	if claim.ExpiresAt-claim.IssuedAt != 50 {
+		t.Errorf("Unknown token timeout should be 50, but was %v\n", claim.ExpiresAt-claim.IssuedAt)
+	}
+
+	// Tests with machine and bootenv (has bad BootParams)
+	rd = dt.NewRenderData(machine, badBootEnv)
+	_, e = rd.Param("bogus")
+	if e == nil {
+		t.Errorf("Param should return an error when machine is not defined in RenderData\n")
+	} else if e.Error() != "No such machine parameter bogus" {
+		t.Errorf("Param should return an error: No such machine parameter bogus, but returned: %s\n", e.Error())
+	}
+	ok = rd.ParamExists("bogus")
+	if ok {
+		t.Errorf("ParamExists should return false when machine is not defined in RenderData\n")
+	}
+
+	// Test machine parameter
+	d, e := rd.Param("foo")
+	if e != nil {
+		t.Errorf("Param foo should NOT return an error: %v\n", e)
+	}
+	s, ok = d.(string)
+	if !ok {
+		t.Errorf("Parameter foo should have been a string\n")
+	} else {
+		if s != "bar" {
+			t.Errorf("Parameter foo should have been bar: %s\n", s)
+		}
+	}
+	ok = rd.ParamExists("foo")
+	if !ok {
+		t.Errorf("ParamExists foo should return true when machine has foo defined in RenderData\n")
+	}
+
+	// Test global parameter
+	d, e = rd.Param("test")
+	if e != nil {
+		t.Errorf("Param test should NOT return an error: %v\n", e)
+	}
+	s, ok = d.(string)
+	if !ok {
+		t.Errorf("Parameter test should have been a string\n")
+	} else {
+		if s != "foreal" {
+			t.Errorf("Parameter test should have been foreal: %s\n", s)
+		}
+	}
+	ok = rd.ParamExists("test")
+	if !ok {
+		t.Errorf("ParamExists test should return true when machine has foo defined in RenderData\n")
+	}
+
+	s, e = rd.BootParams()
+	errString := "template: machine:1:2: executing \"machine\" at <.Param>: error calling Param: No such machine parameter cow"
+	if e == nil {
+		t.Errorf("BootParams with no ENV should have generated an error\n")
+	} else if e.Error() != errString {
+		t.Errorf("BootParams with no ENV should have generated an error: %s, but got %s\n", errString, e.Error())
+	}
+	s = rd.GenerateToken()
+	claim, e = dt.GetToken(s)
+	if e != nil {
+		t.Errorf("GetToken should return a good claim. %v\n", e)
+	}
+	if claim.Match("machines", "post", "anything") {
+		t.Errorf("Known token should NOT match: machines/post/*\n")
+	}
+	if claim.Match("machines", "get", "anything") {
+		t.Errorf("Known token should NOT match: machines/get/*\n")
+	}
+	if claim.Match("machines", "patch", "anything") {
+		t.Errorf("Known token should NOT match: machines/patch/*\n")
+	}
+	if !claim.Match("machines", "get", machine.Key()) {
+		t.Errorf("Known token should match: machines/get/%s\n", machine.Key())
+	}
+	if !claim.Match("machines", "patch", machine.Key()) {
+		t.Errorf("Known token should match: machines/patch/%s\n", machine.Key())
+	}
+	if claim.ExpiresAt-claim.IssuedAt != 3600 {
+		t.Errorf("Known token timeout should be 3600, but was %v\n", claim.ExpiresAt-claim.IssuedAt)
+	}
+	e = dt.SetPrefs(map[string]string{"knownTokenTimeout": "50"})
+	if e != nil {
+		t.Errorf("SetPrefs should not return an error: %v\n", e)
+	}
+	s = rd.GenerateToken()
+	claim, e = dt.GetToken(s)
+	if e != nil {
+		t.Errorf("GetToken should return a good claim. %v\n", e)
+	}
+	if claim.Match("machines", "post", "anything") {
+		t.Errorf("Known token should NOT match: machines/post/*\n")
+	}
+	if claim.Match("machines", "get", "anything") {
+		t.Errorf("Known token should NOT match: machines/get/*\n")
+	}
+	if claim.Match("machines", "patch", "anything") {
+		t.Errorf("Known token should NOT match: machines/patch/*\n")
+	}
+	if !claim.Match("machines", "get", machine.Key()) {
+		t.Errorf("Known token should match: machines/get/%s\n", machine.Key())
+	}
+	if !claim.Match("machines", "patch", machine.Key()) {
+		t.Errorf("Known token should match: machines/patch/%s\n", machine.Key())
+	}
+	if claim.ExpiresAt-claim.IssuedAt != 50 {
+		t.Errorf("Known token timeout should be 50, but was %v\n", claim.ExpiresAt-claim.IssuedAt)
+	}
+
 }

--- a/cli/prefs_test.go
+++ b/cli/prefs_test.go
@@ -7,7 +7,9 @@ import (
 
 var prefsDefaultListString = `{
   "defaultBootEnv": "sledgehammer",
-  "unknownBootEnv": "ignore"
+  "knownTokenTimeout": "3600",
+  "unknownBootEnv": "ignore",
+  "unknownTokenTimeout": "600"
 }
 `
 
@@ -18,7 +20,9 @@ var prefsSetBadJSONErrorString string = "Error: Invalid prefs: error unmarshalin
 var prefsSetEmptyJSONString string = "{}"
 var prefsSetJSONResponseString string = `{
   "defaultBootEnv": "local",
-  "unknownBootEnv": "ignore"
+  "knownTokenTimeout": "3600",
+  "unknownBootEnv": "ignore",
+  "unknownTokenTimeout": "600"
 }
 `
 var prefsSetIllegalJSONResponseString string = "Error: defaultBootEnv: Bootenv illegal does not exist\n\n"
@@ -26,8 +30,9 @@ var prefsSetInvalidPrefResponseString string = "Error: Unknown Preference greg\n
 
 var prefsChangedListString = `{
   "defaultBootEnv": "local",
+  "knownTokenTimeout": "3600",
   "unknownBootEnv": "ignore",
-  "unknownTokenTimeout": "30"
+  "unknownTokenTimeout": "600"
 }
 `
 
@@ -39,12 +44,23 @@ var prefsSetStdinJSONString = `{
 }
 `
 
-var prefsSetJSONBadKnownTokenTimeout = `{
-  "knownTokenTimeout": "local",
-}`
-var prefsSetJSONBadUnknownTokenTimeout = `{
-  "unknownTokenTimeout": "local",
-}`
+var prefsSetBadKnownTokenTimeoutErrorString = "Error: Preference knownTokenTimeout: strconv.Atoi: parsing \"illegal\": invalid syntax\n\n"
+var prefsSetBadUnknownTokenTimeoutErrorString = "Error: Preference unknownTokenTimeout: strconv.Atoi: parsing \"illegal\": invalid syntax\n\n"
+
+var prefsKnownChangedListString = `{
+  "defaultBootEnv": "local",
+  "knownTokenTimeout": "5000",
+  "unknownBootEnv": "ignore",
+  "unknownTokenTimeout": "600"
+}
+`
+var prefsBothChangedListString = `{
+  "defaultBootEnv": "local",
+  "knownTokenTimeout": "5000",
+  "unknownBootEnv": "ignore",
+  "unknownTokenTimeout": "7000"
+}
+`
 
 func TestPrefsCli(t *testing.T) {
 	if err := os.MkdirAll("bootenvs", 0755); err != nil {
@@ -84,13 +100,19 @@ func TestPrefsCli(t *testing.T) {
 		CliTest{false, true, []string{"prefs", "set", "defaultBootEnv", "illegal"}, noStdinString, noContentString, prefsSetIllegalJSONResponseString},
 		CliTest{false, false, []string{"prefs", "list"}, noStdinString, prefsChangedListString, noErrorString},
 
+		CliTest{false, true, []string{"prefs", "set", "knownTokenTimeout", "illegal"}, noStdinString, noContentString, prefsSetBadKnownTokenTimeoutErrorString},
+		CliTest{false, true, []string{"prefs", "set", "unknownTokenTimeout", "illegal"}, noStdinString, noContentString, prefsSetBadUnknownTokenTimeoutErrorString},
+		CliTest{false, false, []string{"prefs", "set", "knownTokenTimeout", "5000"}, noStdinString, prefsKnownChangedListString, noErrorString},
+		CliTest{false, false, []string{"prefs", "set", "unknownTokenTimeout", "7000"}, noStdinString, prefsBothChangedListString, noErrorString},
+		CliTest{false, false, []string{"prefs", "list"}, noStdinString, prefsBothChangedListString, noErrorString},
+
 		CliTest{false, true, []string{"prefs", "set", "greg", "ignore"}, noStdinString, noContentString, prefsSetInvalidPrefResponseString},
-		CliTest{false, false, []string{"prefs", "list"}, noStdinString, prefsChangedListString, noErrorString},
+		CliTest{false, false, []string{"prefs", "list"}, noStdinString, prefsBothChangedListString, noErrorString},
 
 		CliTest{false, true, []string{"prefs", "set", "-"}, prefsSetStdinBadJSONString, noContentString, prefsSetBadJSONErrorString},
-		CliTest{false, false, []string{"prefs", "list"}, noStdinString, prefsChangedListString, noErrorString},
-		CliTest{false, false, []string{"prefs", "set", "-"}, prefsSetStdinJSONString, prefsChangedListString, noErrorString},
-		CliTest{false, false, []string{"prefs", "list"}, noStdinString, prefsChangedListString, noErrorString},
+		CliTest{false, false, []string{"prefs", "list"}, noStdinString, prefsBothChangedListString, noErrorString},
+		CliTest{false, false, []string{"prefs", "set", "-"}, prefsSetStdinJSONString, prefsBothChangedListString, noErrorString},
+		CliTest{false, false, []string{"prefs", "list"}, noStdinString, prefsBothChangedListString, noErrorString},
 
 		// Clean-up - can't happen now.
 	}

--- a/cli/prefs_test.go
+++ b/cli/prefs_test.go
@@ -26,7 +26,8 @@ var prefsSetInvalidPrefResponseString string = "Error: Unknown Preference greg\n
 
 var prefsChangedListString = `{
   "defaultBootEnv": "local",
-  "unknownBootEnv": "ignore"
+  "unknownBootEnv": "ignore",
+  "unknownTokenTimeout": "30"
 }
 `
 
@@ -37,6 +38,13 @@ var prefsSetStdinJSONString = `{
   "unknownBootEnv": "ignore"
 }
 `
+
+var prefsSetJSONBadKnownTokenTimeout = `{
+  "knownTokenTimeout": "local",
+}`
+var prefsSetJSONBadUnknownTokenTimeout = `{
+  "unknownTokenTimeout": "local",
+}`
 
 func TestPrefsCli(t *testing.T) {
 	if err := os.MkdirAll("bootenvs", 0755); err != nil {

--- a/frontend/prefs.go
+++ b/frontend/prefs.go
@@ -2,6 +2,7 @@ package frontend
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/rackn/rocket-skates/backend"
@@ -65,6 +66,14 @@ func (f *Frontend) InitPrefApi() {
 				case "defaultBootEnv", "unknownBootEnv":
 					if !assureAuth(c, f.Logger, "prefs", "post", k) {
 						return
+					}
+					continue
+				case "knownTokenTimeout", "unknownTokenTimeout":
+					if !assureAuth(c, f.Logger, "prefs", "post", k) {
+						return
+					}
+					if _, e := strconv.Atoi(prefs[k]); e != nil {
+						err.Errorf("Preference %s: %v", k, e)
 					}
 					continue
 				default:

--- a/frontend/prefs_test.go
+++ b/frontend/prefs_test.go
@@ -91,4 +91,31 @@ func TestPrefsOps(t *testing.T) {
 	localDTI.ValidateCode(t, http.StatusCreated)
 	localDTI.ValidateContentType(t, "application/json; charset=utf-8")
 	validateMap(t, w, map[string]string{"defaultBootEnv": "james", "unknownBootEnv": "charles"})
+
+	localDTI.DefaultPrefs = map[string]string{"defaultBootEnv": "greg", "unknownBootEnv": "fred"}
+	s, _ = json.Marshal(map[string]string{"knownTokenTimeout": "james"})
+	req, _ = http.NewRequest("POST", "/api/v3/prefs", strings.NewReader(string(s)))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	w = localDTI.RunTest(req)
+	localDTI.ValidateCode(t, http.StatusBadRequest)
+	localDTI.ValidateContentType(t, "application/json; charset=utf-8")
+	validateError(t, w, []string{"Preference knownTokenTimeout: strconv.Atoi: parsing \"james\": invalid syntax"})
+
+	localDTI.DefaultPrefs = map[string]string{"defaultBootEnv": "greg", "unknownBootEnv": "fred"}
+	s, _ = json.Marshal(map[string]string{"unknownTokenTimeout": "charles"})
+	req, _ = http.NewRequest("POST", "/api/v3/prefs", strings.NewReader(string(s)))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	w = localDTI.RunTest(req)
+	localDTI.ValidateCode(t, http.StatusBadRequest)
+	localDTI.ValidateContentType(t, "application/json; charset=utf-8")
+	validateError(t, w, []string{"Preference unknownTokenTimeout: strconv.Atoi: parsing \"charles\": invalid syntax"})
+
+	localDTI.DefaultPrefs = map[string]string{"defaultBootEnv": "greg", "unknownBootEnv": "fred"}
+	s, _ = json.Marshal(map[string]string{"knownTokenTimeout": "50", "unknownTokenTimeout": "40"})
+	req, _ = http.NewRequest("POST", "/api/v3/prefs", strings.NewReader(string(s)))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	w = localDTI.RunTest(req)
+	localDTI.ValidateCode(t, http.StatusCreated)
+	localDTI.ValidateContentType(t, "application/json; charset=utf-8")
+	validateMap(t, w, map[string]string{"defaultBootEnv": "greg", "unknownBootEnv": "fred", "knownTokenTimeout": "50", "unknownTokenTimeout": "40"})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -58,8 +58,8 @@ type ProgOpts struct {
 	CommandURL          string `long:"endpoint" description:"DigitalRebar Endpoint" env:"EXTERNAL_REBAR_ENDPOINT"`
 	DefaultBootEnv      string `long:"default-boot-env" description:"The default bootenv for the nodes" default:"sledgehammer"`
 	UnknownBootEnv      string `long:"unknown-boot-env" description:"The unknown bootenv for the system.  Should be \"ignore\" or \"discovery\"" default:"ignore"`
-	UnknownTokenTimeout int    `long:"unknown-token-timeout" description:"The default timeout in seconds for the machine create authorization token" default:600`
-	KnownTokenTimeout   int    `long:"known-token-timeout" description:"The default timeout in seconds for the machine update authorization token" default:3600`
+	UnknownTokenTimeout int    `long:"unknown-token-timeout" description:"The default timeout in seconds for the machine create authorization token" default:"600"`
+	KnownTokenTimeout   int    `long:"known-token-timeout" description:"The default timeout in seconds for the machine update authorization token" default:"3600"`
 
 	TlsKeyFile  string `long:"tls-key" description:"The TLS Key File" default:"server.key"`
 	TlsCertFile string `long:"tls-cert" description:"The TLS Cert File" default:"server.crt"`

--- a/server/server.go
+++ b/server/server.go
@@ -52,12 +52,14 @@ type ProgOpts struct {
 	FileRoot string `long:"file-root" description:"Root of filesystem we should manage" default:"/var/lib/tftpboot"`
 	DevUI    string `long:"dev-ui" description:"Root of UI Pages for Development"`
 
-	DisableProvisioner bool   `long:"disable-provisioner" description:"Disable provisioner"`
-	DisableDHCP        bool   `long:"disable-dhcp" description:"Disable DHCP"`
-	DhcpInterfaces     string `long:"dhcp-ifs" description:"Comma-seperated list of interfaces to listen for DHCP packets" default:""`
-	CommandURL         string `long:"endpoint" description:"DigitalRebar Endpoint" env:"EXTERNAL_REBAR_ENDPOINT"`
-	DefaultBootEnv     string `long:"default-boot-env" description:"The default bootenv for the nodes" default:"sledgehammer"`
-	UnknownBootEnv     string `long:"unknown-boot-env" description:"The unknown bootenv for the system.  Should be \"ignore\" or \"discovery\"" default:"ignore"`
+	DisableProvisioner  bool   `long:"disable-provisioner" description:"Disable provisioner"`
+	DisableDHCP         bool   `long:"disable-dhcp" description:"Disable DHCP"`
+	DhcpInterfaces      string `long:"dhcp-ifs" description:"Comma-seperated list of interfaces to listen for DHCP packets" default:""`
+	CommandURL          string `long:"endpoint" description:"DigitalRebar Endpoint" env:"EXTERNAL_REBAR_ENDPOINT"`
+	DefaultBootEnv      string `long:"default-boot-env" description:"The default bootenv for the nodes" default:"sledgehammer"`
+	UnknownBootEnv      string `long:"unknown-boot-env" description:"The unknown bootenv for the system.  Should be \"ignore\" or \"discovery\"" default:"ignore"`
+	UnknownTokenTimeout int    `long:"unknown-token-timeout" description:"The default timeout in seconds for the machine create authorization token" default:600`
+	KnownTokenTimeout   int    `long:"known-token-timeout" description:"The default timeout in seconds for the machine update authorization token" default:3600`
 
 	TlsKeyFile  string `long:"tls-key" description:"The TLS Key File" default:"server.key"`
 	TlsCertFile string `long:"tls-cert" description:"The TLS Cert File" default:"server.crt"`
@@ -121,8 +123,10 @@ func Server(c_opts *ProgOpts) {
 		c_opts.ApiPort,
 		logger,
 		map[string]string{
-			"defaultBootEnv": c_opts.DefaultBootEnv,
-			"unknownBootEnv": c_opts.UnknownBootEnv,
+			"defaultBootEnv":      c_opts.DefaultBootEnv,
+			"unknownBootEnv":      c_opts.UnknownBootEnv,
+			"knownTokenTimeout":   fmt.Sprintf("%d", c_opts.KnownTokenTimeout),
+			"unknownTokenTimeout": fmt.Sprintf("%d", c_opts.UnknownTokenTimeout),
 		})
 
 	if err := dt.RenderUnknown(); err != nil {


### PR DESCRIPTION
different tokens based upon the renderer.  This mostly
works with the exception of the start-up.sh script
which is indirectly shared between two bootenvs.  This
means that currently the unknown case needs machine/get
capabilities as well.